### PR TITLE
allow "type" key in args hash to be either a symbol or a string

### DIFF
--- a/lib/librato/metrics/queue.rb
+++ b/lib/librato/metrics/queue.rb
@@ -13,7 +13,7 @@ module Librato
       def add(args)
         args.each do |key, value|
           if value.respond_to?(:each)
-            type = (value.delete(:type) || 'gauge')
+            type = value.delete(:type) || value.delete('type') || 'gauge'
             type = ("#{type}s").to_sym
             value[:name] = key.to_s
             @queued[type] ||= []

--- a/spec/unit/metrics/queue_spec.rb
+++ b/spec/unit/metrics/queue_spec.rb
@@ -26,6 +26,12 @@ module Librato
             expected = {:gauges => [{:name => 'temperature', :value => 34}]}
             subject.queued.should eql expected
           end
+
+          it "should accept type key as string or a symbol" do
+            subject.add :total_visits => {"type" => "counter", :value => 4000}
+            expected = {:counters => [{:name => 'total_visits', :value => 4000}]}
+            subject.queued.should eql expected
+          end
         end
 
         context "with extra attributes" do


### PR DESCRIPTION
Motivation is that we are using this in a Resque job and the hash keys aren't preserved as symbols.  Open to other suggestions if this commit is a bad idea.
