### PR TITLE
Don't reset retries during the retry. Should prevent infinite retry loop.

### DIFF
--- a/lib/librato/metrics/middleware/retry.rb
+++ b/lib/librato/metrics/middleware/retry.rb
@@ -12,13 +12,15 @@ module Librato
 
         def call(env)
           retries = @retries
-          @app.call(env)
-        rescue StandardError, Timeout::Error
-          if retries > 0
-            retries -= 1
-            retry
+          begin
+            @app.call(env)
+          rescue StandardError, Timeout::Error
+            if retries > 0
+              retries -= 1
+              retry
+            end
+            raise
           end
-          raise
         end
         
       end


### PR DESCRIPTION
This breaks the retry loop on 400s (I imagine other error codes as well).
