### PR TITLE
Fix aggregator support for individually specified sources.

### DIFF
--- a/spec/unit/metrics/aggregator_spec.rb
+++ b/spec/unit/metrics/aggregator_spec.rb
@@ -76,6 +76,20 @@ module Librato
             }
             subject.queued.should equal_unordered(expected)
           end
+          
+          it "should respect source argument" do
+            subject.add :foo => {:source => 'alpha', :value => 1}
+            subject.add :foo => 5
+            subject.add :foo => {:source => :alpha, :value => 6}
+            subject.add :foo => 10
+            expected = { :gauges => [
+              { :name => 'foo', :source => 'alpha', :count => 2,
+                :sum => 7.0, :min => 1.0, :max => 6.0 },
+              { :name => 'foo', :count => 2, 
+                :sum => 15.0, :min => 5.0, :max => 10.0 }
+            ]}
+            subject.queued.should equal_unordered(expected)
+          end
         end
 
         context "with multiple hash arguments" do


### PR DESCRIPTION
Previously Aggregator objects silently ignored per-measurement sources, this fixes. So now this:

```
a = Aggregator.new(:source => 'foo')
a.add :bar => 1
a.add :bar => 2
a.add :bar => 3, :source => 'baz'
```

...will return distributions for both 'foo' and 'baz' sources.
