### PR TITLE
add pagination and csv support to 'fetch'

### DIFF
--- a/lib/librato/metrics/client.rb
+++ b/lib/librato/metrics/client.rb
@@ -1,3 +1,5 @@
+require 'csv'
+
 module Librato
   module Metrics
 
@@ -162,9 +164,9 @@ module Librato
 
         csv_measures = {}
         measures.each do |k,v|
-          csv_measures[k] = measures[k].
-            map{|m| "%d,%.6f" % [m['measure_time'],m[key]]}.
-            join("\n")
+          csv_measures[k] = CSV.generate do |csv|
+            measures[k].each {|m| csv << [m['measure_time'], "%.6f" % [m[key]]]}
+          end
         end
 
         csv_measures


### PR DESCRIPTION
Added basic pagination support to `fetch`. If time interval parameters are specified, requests will be made repeatedly until the entire interval of measurements has been fetched.

Also added optional support for returning the fetched measurements formatted as newline separated CSV. Need to add some tests and check for edge cases before merging in, but wanted to get it out there for @nextmat 
