### PR TITLE
Add settable prefix option to queues objects.

### DIFF
--- a/lib/librato/metrics/processor.rb
+++ b/lib/librato/metrics/processor.rb
@@ -85,6 +85,7 @@ module Librato
         @source = options[:source]
         @create_time = Time.now
         @clear_on_failure = options[:clear_failures] || false
+        @prefix = options[:prefix]
       end
       
       def autosubmit_check

--- a/lib/librato/metrics/queue.rb
+++ b/lib/librato/metrics/queue.rb
@@ -28,6 +28,9 @@ module Librato
             metric = {:name => key.to_s, :value => value}
             type = :gauge
           end
+          if @prefix
+            metric[:name] = "#{@prefix}.#{metric[:name]}"
+          end
           type = ("#{type}s").to_sym
           if metric[:measure_time]
             check_measure_time(metric)

--- a/spec/unit/metrics/queue_spec.rb
+++ b/spec/unit/metrics/queue_spec.rb
@@ -71,6 +71,17 @@ module Librato
               :source => 'db2'}]}
             subject.queued.should equal_unordered(expected)
           end
+          
+          context "with a prefix set" do
+            it "should auto-prepend names" do
+              subject = Queue.new(:prefix => 'foo')
+              subject.add :bar => 1
+              subject.add :baz => {:value => 23}
+              expected = {:gauges => [{:name =>'foo.bar', :value => 1, :measure_time => @time}, 
+                                      {:name => 'foo.baz', :value => 23, :measure_time => @time}]}
+              subject.queued.should equal_unordered(expected)
+            end
+          end
         end
 
         context "with multiple metrics" do


### PR DESCRIPTION
Add prefix option to Queues which will auto-prepend any metric names which are added.

```
q = Queue.new(:prefix => 'foo')
q.add :bar => 1  # {:name => 'foo.bar', :value => 1'}
```
