### PR TITLE
Fix problem with MultiJson.dump

### DIFF
--- a/lib/librato/metrics/smart_json.rb
+++ b/lib/librato/metrics/smart_json.rb
@@ -10,15 +10,17 @@ module Librato
           def read(json)
             MultiJson.load(json)
           end
-
-          def write(data)
-            MultiJson.dump(data)
-          end
         else
           def read(json)
             MultiJson.decode(json)
           end
+        end
 
+        if MultiJson.respond_to?(:dump)
+          def write(data)
+            MultiJson.dump(data)
+          end
+        else
           def write(data)
             MultiJson.encode(data)
           end


### PR DESCRIPTION
MultiJson.dump was first introduced in multi_json version 1.3.4, MultiJson.load was however introduced before, making the conditional fail to detect the missing dump-method in some versions of the gem.

This is what is causing `submission failed permanently: undefined method `dump' for MultiJson:Module` in `librato-rails`:
https://github.com/librato/librato-rails/issues/40
