### PR TITLE
Sane default timeouts for all http requests

### DIFF
--- a/lib/librato/metrics/connection.rb
+++ b/lib/librato/metrics/connection.rb
@@ -29,7 +29,10 @@ module Librato
 
       def transport
         raise(NoClientProvided, "No client provided.") unless @client
-        @transport ||= Faraday::Connection.new(:url => api_endpoint + "/v1/") do |f|
+        @transport ||= Faraday::Connection.new(
+          :url => api_endpoint + "/v1/",
+          :request => {:open_timeout => 20, :timeout => 30}) do |f|
+
           f.use Librato::Metrics::Middleware::RequestBody
           f.use Librato::Metrics::Middleware::Retry
           f.use Librato::Metrics::Middleware::CountRequests


### PR DESCRIPTION
Set sane timeouts by default for all requests, eliminates some cases where net::http can hang indefinitely when making a request.

Should fix: librato/librato-rails#58
