### PR TITLE
Update README: Use correct method for querying metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,11 +186,11 @@ Both options are driven by the addition of measurements. Specifically for time-b
 
 Get name and properties for all metrics you have in the system:
 
-    metrics = Librato::Metrics.metrics
+    metrics = Librato::Metrics.list
 
 Get only metrics whose name includes `time`:
 
-    metrics = Librato::Metrics.metrics :name => 'time'
+    metrics = Librato::Metrics.list :name => 'time'
 
 ## Querying Metric Data
 


### PR DESCRIPTION
The inline documentation suggests that `Librato::Metrics.list` is the correct way to query metrics. This small change updates the README to reflect that.
