### PR TITLE
Fix request chunking with a global source or measure_time

### DIFF
--- a/lib/librato/metrics/persistence/direct.rb
+++ b/lib/librato/metrics/persistence/direct.rb
@@ -5,6 +5,7 @@ module Librato
   module Metrics
     module Persistence
       class Direct
+        MEASUREMENT_TYPES = [:gauges, :counters]
 
         # Persist the queued metrics directly to the
         # Metrics web API.
@@ -28,19 +29,30 @@ module Librato
         def chunk_queued(queued, per_request)
           return [queued] if queue_count(queued) <= per_request
           reqs = []
-          queued.each do |metric_type, measurements|
-            if measurements.size <= per_request
-              # we can fit all of this metric type in a single
-              # request, so do so
-              reqs << {metric_type => measurements}
+          # separate metric-containing values from global values
+          globals = fetch_globals(queued)
+          MEASUREMENT_TYPES.each do |metric_type|
+            metrics = queued[metric_type]
+            next unless metrics
+            if metrics.size <= per_request
+              # we can fit all of this metric type in a single request
+              reqs << build_request(metric_type, metrics, globals)
             else
               # going to have to split things up
-              measurements.each_slice(per_request) do |elements|
-                reqs << {metric_type => elements}
+              metrics.each_slice(per_request) do |elements|
+                reqs << build_request(metric_type, elements, globals)
               end
             end
           end
           reqs
+        end
+
+        def build_request(type, metrics, globals)
+          {type => metrics}.merge(globals)
+        end
+
+        def fetch_globals(queued)
+          queued.reject {|k, v| MEASUREMENT_TYPES.include?(k)}
         end
 
         def queue_count(queued)

--- a/spec/integration/metrics/queue_spec.rb
+++ b/spec/integration/metrics/queue_spec.rb
@@ -35,6 +35,26 @@ module Librato
           gauge = Metrics.get_measurements :gauge_5, :count => 1
           gauge['unassigned'][0]['value'].should == 5
         end
+
+        it "should apply globals to each request" do
+          source = 'yogi'
+          measure_time = Time.now.to_i-3
+          queue = Queue.new(
+            :per_request => 3,
+            :source => source,
+            :measure_time => measure_time,
+            :skip_measurement_times => true
+          )
+          (1..5).each do |i|
+            queue.add "gauge_#{i}" => 1
+          end
+          queue.submit
+
+          # verify globals have persisted for all requests
+          gauge = Metrics.get_measurements :gauge_5, :count => 1
+          gauge[source][0]["value"].should eq(1.0)
+          gauge[source][0]["measure_time"].should eq(measure_time)
+        end
       end
 
       it "should respect default and individual sources" do


### PR DESCRIPTION
Fixes bug where auto-chunking large metric sets would break if a global `measure_time` or `source` was set on the Queue or Aggregator object.
