### PR TITLE
Always use client start time to prevent start/end time mismatch

### DIFF
--- a/lib/librato/metrics/annotator.rb
+++ b/lib/librato/metrics/annotator.rb
@@ -31,9 +31,7 @@ module Librato::Metrics
     #
     def add(stream, title, options={})
       options[:title] = title
-      if options[:start_time]
-        options[:start_time] = options[:start_time].to_i
-      end
+      options[:start_time] = (options[:start_time] || Time.now).to_i
       if options[:end_time]
         options[:end_time] = options[:end_time].to_i
       end


### PR DESCRIPTION
Annotation start_time was previously resolved at the API if not specified.
However end_time is always based on client time. In cases of clock drift on
the client this could result in an update end_time submission which is
actually earlier than the start time, causing failures.

Potential fix for #108 