### PR TITLE
Support proxy

### DIFF
--- a/lib/librato/metrics.rb
+++ b/lib/librato/metrics.rb
@@ -74,6 +74,7 @@ module Librato
     #
     def_delegators :client, :agent_identifier, :annotate, :api_endpoint,
                    :api_endpoint=, :authenticate, :connection,
+                   :proxy, :proxy=,
                    :faraday_adapter, :faraday_adapter=,
                    :persistence, :persistence=, :persister,
                    :get_composite, :get_metric, :get_measurements, :metrics,

--- a/lib/librato/metrics/client.rb
+++ b/lib/librato/metrics/client.rb
@@ -6,7 +6,7 @@ module Librato
 
       def_delegator :annotator, :add, :annotate
 
-      attr_accessor :email, :api_key
+      attr_accessor :email, :api_key, :proxy
 
       # Provide agent identifier for the developer program. See:
       # http://support.metrics.librato.com/knowledgebase/articles/53548-developer-program
@@ -66,7 +66,7 @@ module Librato
         # prevent successful creation if no credentials set
         raise CredentialsMissing unless (self.email and self.api_key)
         @connection ||= Connection.new(:client => self, :api_endpoint => api_endpoint,
-                                       :adapter => faraday_adapter)
+                                       :adapter => faraday_adapter, :proxy => self.proxy)
       end
 
       # Overrride user agent for this client's connections. If you

--- a/lib/librato/metrics/connection.rb
+++ b/lib/librato/metrics/connection.rb
@@ -19,6 +19,7 @@ module Librato
         @client = options[:client]
         @api_endpoint = options[:api_endpoint]
         @adapter = options[:adapter]
+        @proxy = options[:proxy]
       end
 
       # API endpoint that will be used for requests.
@@ -39,6 +40,7 @@ module Librato
           f.use Librato::Metrics::Middleware::ExpectsStatus
 
           f.adapter @adapter || Metrics.faraday_adapter
+          f.proxy @proxy if @proxy
         end.tap do |transport|
           transport.headers[:user_agent] = user_agent
           transport.headers[:content_type] = 'application/json'


### PR DESCRIPTION
I added support for the http proxy.

```ruby
Librato::Metrics.authenticate '...', '...'
Librato::Metrics.proxy 'http://proxy.example.com:8080'
Librato::Metrics.submit :my_metric => 42, :my_other_metric => 1002
```

Please merge If there is no problem.