### PR TITLE
Fix issues with source listing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# use container-based infrastructure
+sudo: false
+
 rvm:
   # - 1.8.7
   # - ree

--- a/lib/librato/metrics/client.rb
+++ b/lib/librato/metrics/client.rb
@@ -379,7 +379,8 @@ module Librato
       #
       # @param [Hash] filter
       def sources(filter = {})
-        query = filter[:name] if filter.has_key?(:name)
+        query = {}
+        query[:name] = filter[:name] if filter.has_key?(:name)
         path = "sources"
         Collection.paginated_collection("sources", connection, path, query)
       end

--- a/spec/integration/metrics_spec.rb
+++ b/spec/integration/metrics_spec.rb
@@ -322,6 +322,11 @@ module Librato
           test_source = sources.detect { |s| s["name"] == "sources_api_test" }
           test_source["display_name"].should == "Sources Api Test"
         end
+
+        it "should allow filtering by name" do
+          sources = Metrics.sources name: 'sources_api_test'
+          sources.all? {|s| s['name'] =~ /sources_api_test/}.should be_true
+        end
       end
 
       describe "#get_source" do


### PR DESCRIPTION
`Librato::Metrics.sources` was broken when pagination occurred (i.e. you have more than 100 sources), and did not work at all trying to filter by `:name`. This fixes both of those issues.
/cc @nextmat 