### PR TITLE
Upgrade rspec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
---colour
+--color
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'pry'
 gem 'quixote'
 
 group :test do
-  gem 'rspec', '~> 2.6.0'
+  gem 'rspec', '~> 3.5.0'
   gem 'sinatra'
   gem 'popen4'
 end

--- a/spec/integration/deprecated_methods_spec.rb
+++ b/spec/integration/deprecated_methods_spec.rb
@@ -28,7 +28,7 @@ describe Librato::Metrics do
 
         it { is_expected.not_to be_nil }
 
-        it "should return a metric" do
+        it "returns a metric" do
           expect(metric["name"]).to eq("test_metric")
         end
       end
@@ -40,7 +40,7 @@ describe Librato::Metrics do
         it { is_expected.not_to be_nil }
         it { is_expected.not_to be_empty }
 
-        it "should return the measurements" do
+        it "returns the measurements" do
           expect(measurements).to have_key("unassigned")
           expect(measurements["unassigned"]).to be_an(Array)
           expect(measurements["unassigned"].first["value"]).to eq(123.0)
@@ -55,7 +55,7 @@ describe Librato::Metrics do
       it { is_expected.not_to be_nil }
       it { is_expected.not_to be_empty }
 
-      it "should return the list of metrics" do
+      it "returns the list of metrics" do
         metric = metrics.find { |m| m["name"] == "test_metric" }
         expect(metric).not_to be_nil
       end
@@ -68,13 +68,13 @@ describe Librato::Metrics do
 
       let(:updated_metric) { client.get_metric("test_metric") }
 
-      it "should update the metric" do
+      it "updates the metric" do
         expect(updated_metric["display_name"]).to eq("Test Deprecated Update")
       end
     end
 
     describe "#delete" do
-      it "should delete the metric" do
+      it "deletes the metric" do
         expect(client.metrics(:name => "test_metric")).not_to be_empty
         client.delete("test_metric")
         expect(client.metrics(:name => "test_metric")).to be_empty

--- a/spec/integration/deprecated_methods_spec.rb
+++ b/spec/integration/deprecated_methods_spec.rb
@@ -4,7 +4,7 @@ DEPRECATED_METHODS = %w[fetch list update delete]
 describe Librato::Metrics do
 
   DEPRECATED_METHODS.each do |deprecated_method|
-    it { should respond_to(deprecated_method) }
+    it { is_expected.to respond_to(deprecated_method) }
   end
 
   describe "Client" do
@@ -18,7 +18,7 @@ describe Librato::Metrics do
     end
 
     DEPRECATED_METHODS.each do |deprecated_method|
-      it { should respond_to(deprecated_method) }
+      it { is_expected.to respond_to(deprecated_method) }
     end
 
     describe "#fetch" do
@@ -26,10 +26,10 @@ describe Librato::Metrics do
         let(:metric) { client.fetch(:test_metric) }
         subject { metric }
 
-        it { should_not be_nil }
+        it { is_expected.not_to be_nil }
 
         it "should return a metric" do
-          metric["name"].should == "test_metric"
+          expect(metric["name"]).to eq("test_metric")
         end
       end
 
@@ -37,13 +37,13 @@ describe Librato::Metrics do
         let(:measurements) { client.fetch(:test_metric, :count => 1) }
         subject { measurements }
 
-        it { should_not be_nil }
-        it { should_not be_empty }
+        it { is_expected.not_to be_nil }
+        it { is_expected.not_to be_empty }
 
         it "should return the measurements" do
-          measurements.should have_key("unassigned")
-          measurements["unassigned"].should be_an(Array)
-          measurements["unassigned"].first["value"].should == 123.0
+          expect(measurements).to have_key("unassigned")
+          expect(measurements["unassigned"]).to be_an(Array)
+          expect(measurements["unassigned"].first["value"]).to eq(123.0)
         end
       end
     end
@@ -52,12 +52,12 @@ describe Librato::Metrics do
       let(:metrics) { client.list }
       subject { metrics }
 
-      it { should_not be_nil }
-      it { should_not be_empty }
+      it { is_expected.not_to be_nil }
+      it { is_expected.not_to be_empty }
 
       it "should return the list of metrics" do
         metric = metrics.find { |m| m["name"] == "test_metric" }
-        metric.should_not be_nil
+        expect(metric).not_to be_nil
       end
     end
 
@@ -69,15 +69,15 @@ describe Librato::Metrics do
       let(:updated_metric) { client.get_metric("test_metric") }
 
       it "should update the metric" do
-        updated_metric["display_name"].should == "Test Deprecated Update"
+        expect(updated_metric["display_name"]).to eq("Test Deprecated Update")
       end
     end
 
     describe "#delete" do
       it "should delete the metric" do
-        client.metrics(:name => "test_metric").should_not be_empty
+        expect(client.metrics(:name => "test_metric")).not_to be_empty
         client.delete("test_metric")
-        client.metrics(:name => "test_metric").should be_empty
+        expect(client.metrics(:name => "test_metric")).to be_empty
       end
     end
 

--- a/spec/integration/metrics/annotator_spec.rb
+++ b/spec/integration/metrics/annotator_spec.rb
@@ -11,15 +11,15 @@ module Librato
         it "should create new annotation" do
           subject.add :deployment, "deployed v68"
           annos = subject.fetch(:deployment, :start_time => Time.now.to_i-60)
-          annos["events"]["unassigned"].length.should == 1
-          annos["events"]["unassigned"][0]["title"].should == 'deployed v68'
+          expect(annos["events"]["unassigned"].length).to eq(1)
+          expect(annos["events"]["unassigned"][0]["title"]).to eq('deployed v68')
         end
         it "should support sources" do
           subject.add :deployment, 'deployed v69', :source => 'box1'
           annos = subject.fetch(:deployment, :start_time => Time.now.to_i-60)
-          annos["events"]["box1"].length.should == 1
+          expect(annos["events"]["box1"].length).to eq(1)
           first = annos["events"]["box1"][0]
-          first['title'].should == 'deployed v69'
+          expect(first['title']).to eq('deployed v69')
         end
         it "should support start and end times" do
           start_time = Time.now.to_i-120
@@ -27,23 +27,23 @@ module Librato
           subject.add :deployment, 'deployed v70', :start_time => start_time,
                       :end_time => end_time
           annos = subject.fetch(:deployment, :start_time => Time.now.to_i-180)
-          annos["events"]["unassigned"].length.should == 1
+          expect(annos["events"]["unassigned"].length).to eq(1)
           first = annos["events"]["unassigned"][0]
-          first['title'].should == 'deployed v70'
-          first['start_time'].should == start_time
-          first['end_time'].should == end_time
+          expect(first['title']).to eq('deployed v70')
+          expect(first['start_time']).to eq(start_time)
+          expect(first['end_time']).to eq(end_time)
         end
         it "should support description" do
           subject.add :deployment, 'deployed v71', :description => 'deployed foobar!'
           annos = subject.fetch(:deployment, :start_time => Time.now.to_i-180)
-          annos["events"]["unassigned"].length.should == 1
+          expect(annos["events"]["unassigned"].length).to eq(1)
           first = annos["events"]["unassigned"][0]
-          first['title'].should == 'deployed v71'
-          first['description'].should == 'deployed foobar!'
+          expect(first['title']).to eq('deployed v71')
+          expect(first['description']).to eq('deployed foobar!')
         end
         it "should have an id for further use" do
           annotation = subject.add :deployment, "deployed v23"
-          annotation['id'].should_not be_nil
+          expect(annotation['id']).not_to be_nil
         end
 
         context "with a block" do
@@ -52,8 +52,8 @@ module Librato
               sleep 1.0
             end
             data = subject.fetch_event 'deploys', annotation['id']
-            data['start_time'].should_not be_nil
-            data['end_time'].should_not be_nil
+            expect(data['start_time']).not_to be_nil
+            expect(data['end_time']).not_to be_nil
           end
         end
       end
@@ -63,9 +63,9 @@ module Librato
           subject.add :deployment, "deployed v45"
           subject.fetch :deployment # should exist
           subject.delete :deployment
-          lambda {
+          expect {
             subject.fetch(:deployment)
-          }.should raise_error(Metrics::NotFound)
+          }.to raise_error(Metrics::NotFound)
         end
       end
 
@@ -82,8 +82,8 @@ module Librato
           subject.delete_event :deployment, ids['deployed v47']
           events = subject.fetch(:deployment, :start_time => Time.now.to_i-60)
           events = events['events']['unassigned']
-          events.length.should == 1
-          events[0]['title'].should == 'deployed v46'
+          expect(events.length).to eq(1)
+          expect(events[0]['title']).to eq('deployed v46')
         end
       end
 
@@ -92,7 +92,7 @@ module Librato
           it "should return stream properties" do
             subject.add :backups, "backup 21"
             properties = subject.fetch :backups
-            properties['name'].should == 'backups'
+            expect(properties['name']).to eq('backups')
           end
         end
 
@@ -102,8 +102,8 @@ module Librato
             subject.add :backups, "backup 23"
             annos = subject.fetch :backups, :start_time => Time.now.to_i-60
             events = annos['events']['unassigned']
-            events[0]['title'].should == 'backup 22'
-            events[1]['title'].should == 'backup 23'
+            expect(events[0]['title']).to eq('backup 22')
+            expect(events[1]['title']).to eq('backup 23')
           end
           it "should respect source limits" do
             subject.add :backups, "backup 24", :source => 'server_1'
@@ -111,16 +111,16 @@ module Librato
             subject.add :backups, "backup 26", :source => 'server_3'
             annos = subject.fetch :backups, :start_time => Time.now.to_i-60,
                                   :sources => %w{server_1 server_3}
-            annos['events']['server_1'].should_not be_nil
-            annos['events']['server_2'].should be_nil
-            annos['events']['server_3'].should_not be_nil
+            expect(annos['events']['server_1']).not_to be_nil
+            expect(annos['events']['server_2']).to be_nil
+            expect(annos['events']['server_3']).not_to be_nil
           end
         end
 
         it "should return exception if annotation is missing" do
-          lambda {
+          expect {
             subject.fetch :backups
-          }.should raise_error(Metrics::NotFound)
+          }.to raise_error(Metrics::NotFound)
         end
       end
 
@@ -129,14 +129,14 @@ module Librato
           it "should return event properties" do
             annotation = subject.add 'deploys', 'v69'
             data = subject.fetch_event 'deploys', annotation['id']
-            data['title'].should == 'v69'
+            expect(data['title']).to eq('v69')
           end
         end
         context "when event doesn't exist" do
           it "should raise NotFound" do
-            lambda {
+            expect {
               data = subject.fetch_event 'deploys', 324
-            }.should raise_error(Metrics::NotFound)
+            }.to raise_error(Metrics::NotFound)
           end
         end
       end
@@ -150,18 +150,18 @@ module Librato
         context "without arguments" do
           it "should list annotation streams" do
             streams = subject.list
-            streams['annotations'].length.should == 2
+            expect(streams['annotations'].length).to eq(2)
             streams = streams['annotations'].map{|i| i['name']}
-            streams.should include('backups')
-            streams.should include('deployment')
+            expect(streams).to include('backups')
+            expect(streams).to include('deployment')
           end
         end
         context "with an argument" do
           it "should list annotation streams which match" do
             streams = subject.list :name => 'back'
-            streams['annotations'].length.should == 1
+            expect(streams['annotations'].length).to eq(1)
             streams = streams['annotations'].map{|i| i['name']}
-            streams.should include('backups')
+            expect(streams).to include('backups')
           end
         end
       end
@@ -175,8 +175,8 @@ module Librato
               :end_time => end_time, :title => 'v28'
             data = subject.fetch_event 'deploys', annotation['id']
 
-            data['title'].should == 'v28'
-            data['end_time'].should == end_time
+            expect(data['title']).to eq('v28')
+            expect(data['end_time']).to eq(end_time)
           end
         end
         context "when event does not exist" do

--- a/spec/integration/metrics/annotator_spec.rb
+++ b/spec/integration/metrics/annotator_spec.rb
@@ -8,20 +8,20 @@ module Librato
       before(:each) { delete_all_annotations }
 
       describe "#add" do
-        it "should create new annotation" do
+        it "creates new annotation" do
           subject.add :deployment, "deployed v68"
           annos = subject.fetch(:deployment, :start_time => Time.now.to_i-60)
           expect(annos["events"]["unassigned"].length).to eq(1)
           expect(annos["events"]["unassigned"][0]["title"]).to eq('deployed v68')
         end
-        it "should support sources" do
+        it "supports sources" do
           subject.add :deployment, 'deployed v69', :source => 'box1'
           annos = subject.fetch(:deployment, :start_time => Time.now.to_i-60)
           expect(annos["events"]["box1"].length).to eq(1)
           first = annos["events"]["box1"][0]
           expect(first['title']).to eq('deployed v69')
         end
-        it "should support start and end times" do
+        it "supports start and end times" do
           start_time = Time.now.to_i-120
           end_time = Time.now.to_i-30
           subject.add :deployment, 'deployed v70', :start_time => start_time,
@@ -33,7 +33,7 @@ module Librato
           expect(first['start_time']).to eq(start_time)
           expect(first['end_time']).to eq(end_time)
         end
-        it "should support description" do
+        it "supports description" do
           subject.add :deployment, 'deployed v71', :description => 'deployed foobar!'
           annos = subject.fetch(:deployment, :start_time => Time.now.to_i-180)
           expect(annos["events"]["unassigned"].length).to eq(1)
@@ -41,13 +41,13 @@ module Librato
           expect(first['title']).to eq('deployed v71')
           expect(first['description']).to eq('deployed foobar!')
         end
-        it "should have an id for further use" do
+        it "has an id for further use" do
           annotation = subject.add :deployment, "deployed v23"
           expect(annotation['id']).not_to be_nil
         end
 
         context "with a block" do
-          it "should set both start and end times" do
+          it "sets both start and end times" do
             annotation = subject.add 'deploys', 'v345' do
               sleep 1.0
             end
@@ -59,7 +59,7 @@ module Librato
       end
 
       describe "#delete" do
-        it "should remove annotation streams" do
+        it "removes annotation streams" do
           subject.add :deployment, "deployed v45"
           subject.fetch :deployment # should exist
           subject.delete :deployment
@@ -70,7 +70,7 @@ module Librato
       end
 
       describe "#delete_event" do
-        it "should remove an annotation event" do
+        it "removes an annotation event" do
           subject.add :deployment, 'deployed v46'
           subject.add :deployment, 'deployed v47'
           events = subject.fetch(:deployment, :start_time => Time.now.to_i-60)
@@ -89,7 +89,7 @@ module Librato
 
       describe "#fetch" do
         context "without a time frame" do
-          it "should return stream properties" do
+          it "returns stream properties" do
             subject.add :backups, "backup 21"
             properties = subject.fetch :backups
             expect(properties['name']).to eq('backups')
@@ -97,7 +97,7 @@ module Librato
         end
 
         context "with a time frame" do
-          it "should return set of annotations" do
+          it "returns set of annotations" do
             subject.add :backups, "backup 22"
             subject.add :backups, "backup 23"
             annos = subject.fetch :backups, :start_time => Time.now.to_i-60
@@ -105,7 +105,7 @@ module Librato
             expect(events[0]['title']).to eq('backup 22')
             expect(events[1]['title']).to eq('backup 23')
           end
-          it "should respect source limits" do
+          it "respects source limits" do
             subject.add :backups, "backup 24", :source => 'server_1'
             subject.add :backups, "backup 25", :source => 'server_2'
             subject.add :backups, "backup 26", :source => 'server_3'
@@ -117,7 +117,7 @@ module Librato
           end
         end
 
-        it "should return exception if annotation is missing" do
+        it "returns exception if annotation is missing" do
           expect {
             subject.fetch :backups
           }.to raise_error(Metrics::NotFound)
@@ -126,14 +126,14 @@ module Librato
 
       describe "#fetch_event" do
         context "with existing event" do
-          it "should return event properties" do
+          it "returns event properties" do
             annotation = subject.add 'deploys', 'v69'
             data = subject.fetch_event 'deploys', annotation['id']
             expect(data['title']).to eq('v69')
           end
         end
         context "when event doesn't exist" do
-          it "should raise NotFound" do
+          it "raises NotFound" do
             expect {
               data = subject.fetch_event 'deploys', 324
             }.to raise_error(Metrics::NotFound)
@@ -148,7 +148,7 @@ module Librato
         end
 
         context "without arguments" do
-          it "should list annotation streams" do
+          it "lists annotation streams" do
             streams = subject.list
             expect(streams['annotations'].length).to eq(2)
             streams = streams['annotations'].map{|i| i['name']}
@@ -157,7 +157,7 @@ module Librato
           end
         end
         context "with an argument" do
-          it "should list annotation streams which match" do
+          it "lists annotation streams which match" do
             streams = subject.list :name => 'back'
             expect(streams['annotations'].length).to eq(1)
             streams = streams['annotations'].map{|i| i['name']}
@@ -168,7 +168,7 @@ module Librato
 
       describe "#update_event" do
         context "when event exists" do
-          it "should update event" do
+          it "updates event" do
             end_time = (Time.now + 60).to_i
             annotation = subject.add 'deploys', 'v24'
             subject.update_event 'deploys', annotation['id'],

--- a/spec/integration/metrics/middleware/count_requests_spec.rb
+++ b/spec/integration/metrics/middleware/count_requests_spec.rb
@@ -11,14 +11,14 @@ module Librato
           CountRequests.reset
           Metrics.submit :foo => 123
           Metrics.submit :foo => 135
-          CountRequests.total_requests.should == 2
+          expect(CountRequests.total_requests).to eq(2)
         end
 
         it "should be resettable" do
           Metrics.submit :foo => 123
-          CountRequests.total_requests.should > 0
+          expect(CountRequests.total_requests).to be > 0
           CountRequests.reset
-          CountRequests.total_requests.should == 0
+          expect(CountRequests.total_requests).to eq(0)
         end
 
       end

--- a/spec/integration/metrics/middleware/count_requests_spec.rb
+++ b/spec/integration/metrics/middleware/count_requests_spec.rb
@@ -7,14 +7,14 @@ module Librato
       describe CountRequests do
         before(:all) { prep_integration_tests }
 
-        it "should count requests" do
+        it "counts requests" do
           CountRequests.reset
           Metrics.submit :foo => 123
           Metrics.submit :foo => 135
           expect(CountRequests.total_requests).to eq(2)
         end
 
-        it "should be resettable" do
+        it "is resettable" do
           Metrics.submit :foo => 123
           expect(CountRequests.total_requests).to be > 0
           CountRequests.reset

--- a/spec/integration/metrics/queue_spec.rb
+++ b/spec/integration/metrics/queue_spec.rb
@@ -15,7 +15,7 @@ module Librato
             queue.add "gauge_#{i}" => 1
           end
           queue.submit
-          Middleware::CountRequests.total_requests.should == 4
+          expect(Middleware::CountRequests.total_requests).to eq(4)
         end
 
         it "should persist all metrics" do
@@ -29,11 +29,11 @@ module Librato
           queue.submit
 
           metrics = Metrics.list
-          metrics.length.should == 8
+          expect(metrics.length).to eq(8)
           counter = Metrics.get_measurements :counter_3, :count => 1
-          counter['unassigned'][0]['value'].should == 3
+          expect(counter['unassigned'][0]['value']).to eq(3)
           gauge = Metrics.get_measurements :gauge_5, :count => 1
-          gauge['unassigned'][0]['value'].should == 5
+          expect(gauge['unassigned'][0]['value']).to eq(5)
         end
 
         it "should apply globals to each request" do
@@ -52,8 +52,8 @@ module Librato
 
           # verify globals have persisted for all requests
           gauge = Metrics.get_measurements :gauge_5, :count => 1
-          gauge[source][0]["value"].should eq(1.0)
-          gauge[source][0]["measure_time"].should eq(measure_time)
+          expect(gauge[source][0]["value"]).to eq(1.0)
+          expect(gauge[source][0]["measure_time"]).to eq(measure_time)
         end
       end
 
@@ -64,10 +64,10 @@ module Librato
         queue.submit
 
         foo = Metrics.get_measurements :foo, :count => 2
-        foo['default'][0]['value'].should == 123
+        expect(foo['default'][0]['value']).to eq(123)
 
         bar = Metrics.get_measurements :bar, :count => 2
-        bar['barsource'][0]['value'].should == 456
+        expect(bar['barsource'][0]['value']).to eq(456)
       end
 
     end

--- a/spec/integration/metrics/queue_spec.rb
+++ b/spec/integration/metrics/queue_spec.rb
@@ -8,7 +8,7 @@ module Librato
       before(:each) { delete_all_metrics }
 
       context "with a large number of metrics" do
-        it "should submit them in multiple requests" do
+        it "submits them in multiple requests" do
           Middleware::CountRequests.reset
           queue = Queue.new(:per_request => 3)
           (1..10).each do |i|
@@ -18,7 +18,7 @@ module Librato
           expect(Middleware::CountRequests.total_requests).to eq(4)
         end
 
-        it "should persist all metrics" do
+        it "persists all metrics" do
           queue = Queue.new(:per_request => 2)
           (1..5).each do |i|
             queue.add "gauge_#{i}" => i
@@ -36,7 +36,7 @@ module Librato
           expect(gauge['unassigned'][0]['value']).to eq(5)
         end
 
-        it "should apply globals to each request" do
+        it "applies globals to each request" do
           source = 'yogi'
           measure_time = Time.now.to_i-3
           queue = Queue.new(
@@ -57,7 +57,7 @@ module Librato
         end
       end
 
-      it "should respect default and individual sources" do
+      it "respects default and individual sources" do
         queue = Queue.new(:source => 'default')
         queue.add :foo => 123
         queue.add :bar => {:value => 456, :source => 'barsource'}

--- a/spec/integration/metrics_spec.rb
+++ b/spec/integration/metrics_spec.rb
@@ -46,7 +46,7 @@ module Librato
     describe "#delete_metrics" do
       before(:each) { delete_all_metrics }
 
-      context 'by names' do
+      context 'with names' do
 
         context "with a single argument" do
           it "deletes named metric" do
@@ -85,7 +85,7 @@ module Librato
 
       end
 
-      context 'by pattern' do
+      context 'with patterns' do
         it "filters properly" do
           Metrics.submit :foo => 1, :foobar => 2, :foobaz => 3, :bar => 4
           Metrics.delete_metrics :names => 'fo*', :exclude => ['foobar']

--- a/spec/integration/metrics_spec.rb
+++ b/spec/integration/metrics_spec.rb
@@ -8,20 +8,20 @@ module Librato
       before(:all) { @annotator = Metrics::Annotator.new }
       before(:each) { delete_all_annotations }
 
-      it "should create new annotation" do
+      it "creates new annotation" do
         Metrics.annotate :deployment, "deployed v68"
         annos = @annotator.fetch(:deployment, :start_time => Time.now.to_i-60)
         expect(annos["events"]["unassigned"].length).to eq(1)
         expect(annos["events"]["unassigned"][0]["title"]).to eq('deployed v68')
       end
-      it "should support sources" do
+      it "supports sources" do
         Metrics.annotate :deployment, 'deployed v69', :source => 'box1'
         annos = @annotator.fetch(:deployment, :start_time => Time.now.to_i-60)
         expect(annos["events"]["box1"].length).to eq(1)
         first = annos["events"]["box1"][0]
         expect(first['title']).to eq('deployed v69')
       end
-      it "should support start and end times" do
+      it "supports start and end times" do
         start_time = Time.now.to_i-120
         end_time = Time.now.to_i-30
         Metrics.annotate :deployment, 'deployed v70', :start_time => start_time,
@@ -33,7 +33,7 @@ module Librato
         expect(first['start_time']).to eq(start_time)
         expect(first['end_time']).to eq(end_time)
       end
-      it "should support description" do
+      it "supports description" do
         Metrics.annotate :deployment, 'deployed v71', :description => 'deployed foobar!'
         annos = @annotator.fetch(:deployment, :start_time => Time.now.to_i-180)
         expect(annos["events"]["unassigned"].length).to eq(1)
@@ -49,7 +49,7 @@ module Librato
       context 'by names' do
 
         context "with a single argument" do
-          it "should delete named metric" do
+          it "deletes named metric" do
             Metrics.submit :foo => 123
             expect(Metrics.metrics(:name => :foo)).not_to be_empty
             Metrics.delete_metrics :foo
@@ -58,7 +58,7 @@ module Librato
         end
 
         context "with multiple arguments" do
-          it "should delete named metrics" do
+          it "deletes named metrics" do
             Metrics.submit :foo => 123, :bar => 345, :baz => 567
             Metrics.delete_metrics :foo, :bar
             expect(Metrics.metrics(:name => :foo)).to be_empty
@@ -68,7 +68,7 @@ module Librato
         end
 
         context "with missing metric" do
-          it "should run cleanly" do
+          it "runs cleanly" do
             # the API currently returns success even if
             # the metric has already been deleted or is absent.
             Metrics.delete_metrics :missing
@@ -76,7 +76,7 @@ module Librato
         end
 
         context "with no arguments" do
-          it "should not make request" do
+          it "does not make request" do
             expect {
               Metrics.delete_metrics
             }.to raise_error(Metrics::NoMetricsProvided)
@@ -86,7 +86,7 @@ module Librato
       end
 
       context 'by pattern' do
-        it "should filter properly" do
+        it "filters properly" do
           Metrics.submit :foo => 1, :foobar => 2, :foobaz => 3, :bar => 4
           Metrics.delete_metrics :names => 'fo*', :exclude => ['foobar']
 
@@ -116,7 +116,7 @@ module Librato
       end
 
       context "without arguments" do
-        it "should get metric attributes" do
+        it "gets metric attributes" do
           metric = Metrics.get_metric :my_counter
           expect(metric['name']).to eq('my_counter')
           expect(metric['type']).to eq('counter')
@@ -124,7 +124,7 @@ module Librato
       end
 
       context "with a start_time" do
-        it "should return entries since that time" do
+        it "returns entries since that time" do
           # 1 hr ago
           metric = Metrics.get_metric :my_counter, :start_time => Time.now-3600
           data = metric['measurements']
@@ -134,7 +134,7 @@ module Librato
       end
 
       context "with a count limit" do
-        it "should return that number of entries per source" do
+        it "returns that number of entries per source" do
           metric = Metrics.get_metric :my_counter, :count => 2
           data = metric['measurements']
           expect(data['unassigned'].length).to eq(2)
@@ -143,7 +143,7 @@ module Librato
       end
 
       context "with a source limit" do
-        it "should only return that source" do
+        it "only returns that source" do
           metric = Metrics.get_metric :my_counter, :source => 'baz', :start_time => Time.now-3600
           data = metric['measurements']
           expect(data['baz'].length).to eq(2)
@@ -160,14 +160,14 @@ module Librato
       end
 
       context "without arguments" do
-        it "should list all metrics" do
+        it "lists all metrics" do
           metric_names = Metrics.metrics.map { |metric| metric['name'] }
           expect(metric_names.sort).to eq(%w{foo bar baz foo_2}.sort)
         end
       end
 
       context "with a name argument" do
-        it "should list metrics that match" do
+        it "lists metrics that match" do
           metric_names = Metrics.metrics(:name => 'foo').map { |metric| metric['name'] }
           expect(metric_names.sort).to eq(%w{foo foo_2}.sort)
         end
@@ -183,13 +183,13 @@ module Librato
           Metrics.submit :foo => 123
         end
 
-        it "should create the metrics" do
+        it "creates the metrics" do
           metric = Metrics.metrics[0]
           expect(metric['name']).to eq('foo')
           expect(metric['type']).to eq('gauge')
         end
 
-        it "should store their data" do
+        it "stores their data" do
           data = Metrics.get_measurements :foo, :count => 1
           expect(data).not_to be_empty
           data['unassigned'][0]['value'] == 123.0
@@ -202,20 +202,20 @@ module Librato
           Metrics.submit :bar => {:type => :counter, :source => 'baz', :value => 456}
         end
 
-        it "should create the metrics" do
+        it "creates the metrics" do
           metric = Metrics.metrics[0]
           expect(metric['name']).to eq('bar')
           expect(metric['type']).to eq('counter')
         end
 
-        it "should store their data" do
+        it "stores their data" do
           data = Metrics.get_measurements :bar, :count => 1
           expect(data).not_to be_empty
           data['baz'][0]['value'] == 456.0
         end
       end
 
-      it "should not retain errors" do
+      it "does not retain errors" do
         delete_all_metrics
         Metrics.submit :foo => {:type => :counter, :value => 12}
         expect {
@@ -237,7 +237,7 @@ module Librato
             Metrics.submit :foo => 123
           end
 
-          it "should update the metric" do
+          it "updates the metric" do
             Metrics.update_metric :foo, :display_name => "Foo Metric",
                                         :period => 15,
                                         :attributes => {
@@ -251,7 +251,7 @@ module Librato
         end
 
         context "without an existing metric" do
-          it "should create the metric if type specified" do
+          it "creates the metric if type specified" do
             delete_all_metrics
             Metrics.update_metric :foo, :display_name => "Foo Metric",
                                         :type => 'gauge',
@@ -265,7 +265,7 @@ module Librato
             expect(foo['attributes']['display_max']).to eq(1000)
           end
 
-          it "should raise error if no type specified" do
+          it "raises error if no type specified" do
             delete_all_metrics
             expect {
               Metrics.update_metric :foo, :display_name => "Foo Metric",
@@ -285,7 +285,7 @@ module Librato
           Metrics.submit 'my.1' => 1, 'my.2' => 2, 'my.3' => 3, 'my.4' => 4
         end
 
-        it "should support named list" do
+        it "supports named list" do
           names = ['my.1', 'my.3']
           Metrics.update_metrics :names => names, :period => 60
 
@@ -295,7 +295,7 @@ module Librato
            end
         end
 
-        it "should support patterns" do
+        it "supports patterns" do
           Metrics.update_metrics :names => 'my.*', :exclude => ['my.3'],
             :display_max => 100
 
@@ -316,35 +316,35 @@ module Librato
       end
 
       describe "#sources" do
-        it "should work" do
+        it "works" do
           sources = Metrics.sources
           expect(sources).to be_an(Array)
           test_source = sources.detect { |s| s["name"] == "sources_api_test" }
           expect(test_source["display_name"]).to eq("Sources Api Test")
         end
 
-        it "should allow filtering by name" do
+        it "allows filtering by name" do
           sources = Metrics.sources name: 'sources_api_test'
           expect(sources.all? {|s| s['name'] =~ /sources_api_test/}).to be_truthy
         end
       end
 
       describe "#get_source" do
-        it "should work" do
+        it "works" do
           test_source = Metrics.get_source("sources_api_test")
           expect(test_source["display_name"]).to eq("Sources Api Test")
         end
       end
 
       describe "#update_source" do
-        it "should update an existing source" do
+        it "updates an existing source" do
           Metrics.update_source("sources_api_test", display_name: "Updated Source Name")
 
           test_source = Metrics.get_source("sources_api_test")
           expect(test_source["display_name"]).to eq("Updated Source Name")
         end
 
-        it "should create new sources" do
+        it "creates new sources" do
           source_name = "sources_api_test_#{Time.now.to_f}"
           expect {
             no_source = Metrics.get_source(source_name)

--- a/spec/integration/metrics_spec.rb
+++ b/spec/integration/metrics_spec.rb
@@ -11,15 +11,15 @@ module Librato
       it "should create new annotation" do
         Metrics.annotate :deployment, "deployed v68"
         annos = @annotator.fetch(:deployment, :start_time => Time.now.to_i-60)
-        annos["events"]["unassigned"].length.should == 1
-        annos["events"]["unassigned"][0]["title"].should == 'deployed v68'
+        expect(annos["events"]["unassigned"].length).to eq(1)
+        expect(annos["events"]["unassigned"][0]["title"]).to eq('deployed v68')
       end
       it "should support sources" do
         Metrics.annotate :deployment, 'deployed v69', :source => 'box1'
         annos = @annotator.fetch(:deployment, :start_time => Time.now.to_i-60)
-        annos["events"]["box1"].length.should == 1
+        expect(annos["events"]["box1"].length).to eq(1)
         first = annos["events"]["box1"][0]
-        first['title'].should == 'deployed v69'
+        expect(first['title']).to eq('deployed v69')
       end
       it "should support start and end times" do
         start_time = Time.now.to_i-120
@@ -27,19 +27,19 @@ module Librato
         Metrics.annotate :deployment, 'deployed v70', :start_time => start_time,
                     :end_time => end_time
         annos = @annotator.fetch(:deployment, :start_time => Time.now.to_i-180)
-        annos["events"]["unassigned"].length.should == 1
+        expect(annos["events"]["unassigned"].length).to eq(1)
         first = annos["events"]["unassigned"][0]
-        first['title'].should == 'deployed v70'
-        first['start_time'].should == start_time
-        first['end_time'].should == end_time
+        expect(first['title']).to eq('deployed v70')
+        expect(first['start_time']).to eq(start_time)
+        expect(first['end_time']).to eq(end_time)
       end
       it "should support description" do
         Metrics.annotate :deployment, 'deployed v71', :description => 'deployed foobar!'
         annos = @annotator.fetch(:deployment, :start_time => Time.now.to_i-180)
-        annos["events"]["unassigned"].length.should == 1
+        expect(annos["events"]["unassigned"].length).to eq(1)
         first = annos["events"]["unassigned"][0]
-        first['title'].should == 'deployed v71'
-        first['description'].should == 'deployed foobar!'
+        expect(first['title']).to eq('deployed v71')
+        expect(first['description']).to eq('deployed foobar!')
       end
     end
 
@@ -51,9 +51,9 @@ module Librato
         context "with a single argument" do
           it "should delete named metric" do
             Metrics.submit :foo => 123
-            Metrics.metrics(:name => :foo).should_not be_empty
+            expect(Metrics.metrics(:name => :foo)).not_to be_empty
             Metrics.delete_metrics :foo
-            Metrics.metrics(:name => :foo).should be_empty
+            expect(Metrics.metrics(:name => :foo)).to be_empty
           end
         end
 
@@ -61,9 +61,9 @@ module Librato
           it "should delete named metrics" do
             Metrics.submit :foo => 123, :bar => 345, :baz => 567
             Metrics.delete_metrics :foo, :bar
-            Metrics.metrics(:name => :foo).should be_empty
-            Metrics.metrics(:name => :bar).should be_empty
-            Metrics.metrics(:name => :baz).should_not be_empty
+            expect(Metrics.metrics(:name => :foo)).to be_empty
+            expect(Metrics.metrics(:name => :bar)).to be_empty
+            expect(Metrics.metrics(:name => :baz)).not_to be_empty
           end
         end
 
@@ -77,9 +77,9 @@ module Librato
 
         context "with no arguments" do
           it "should not make request" do
-            lambda {
+            expect {
               Metrics.delete_metrics
-            }.should raise_error(Metrics::NoMetricsProvided)
+            }.to raise_error(Metrics::NoMetricsProvided)
           end
         end
 
@@ -91,9 +91,9 @@ module Librato
           Metrics.delete_metrics :names => 'fo*', :exclude => ['foobar']
 
           %w{foo foobaz}.each do |name|
-            lambda {
+            expect {
               Metrics.get_metric name
-            }.should raise_error(Librato::Metrics::NotFound)
+            }.to raise_error(Librato::Metrics::NotFound)
           end
 
           %w{foobar bar}.each do |name|
@@ -118,8 +118,8 @@ module Librato
       context "without arguments" do
         it "should get metric attributes" do
           metric = Metrics.get_metric :my_counter
-          metric['name'].should == 'my_counter'
-          metric['type'].should == 'counter'
+          expect(metric['name']).to eq('my_counter')
+          expect(metric['type']).to eq('counter')
         end
       end
 
@@ -128,8 +128,8 @@ module Librato
           # 1 hr ago
           metric = Metrics.get_metric :my_counter, :start_time => Time.now-3600
           data = metric['measurements']
-          data['unassigned'].length.should == 3
-          data['baz'].length.should == 2
+          expect(data['unassigned'].length).to eq(3)
+          expect(data['baz'].length).to eq(2)
         end
       end
 
@@ -137,8 +137,8 @@ module Librato
         it "should return that number of entries per source" do
           metric = Metrics.get_metric :my_counter, :count => 2
           data = metric['measurements']
-          data['unassigned'].length.should == 2
-          data['baz'].length.should == 2
+          expect(data['unassigned'].length).to eq(2)
+          expect(data['baz'].length).to eq(2)
         end
       end
 
@@ -146,8 +146,8 @@ module Librato
         it "should only return that source" do
           metric = Metrics.get_metric :my_counter, :source => 'baz', :start_time => Time.now-3600
           data = metric['measurements']
-          data['baz'].length.should == 2
-          data['unassigned'].should be_nil
+          expect(data['baz'].length).to eq(2)
+          expect(data['unassigned']).to be_nil
         end
       end
 
@@ -162,14 +162,14 @@ module Librato
       context "without arguments" do
         it "should list all metrics" do
           metric_names = Metrics.metrics.map { |metric| metric['name'] }
-          metric_names.sort.should == %w{foo bar baz foo_2}.sort
+          expect(metric_names.sort).to eq(%w{foo bar baz foo_2}.sort)
         end
       end
 
       context "with a name argument" do
         it "should list metrics that match" do
           metric_names = Metrics.metrics(:name => 'foo').map { |metric| metric['name'] }
-          metric_names.sort.should == %w{foo foo_2}.sort
+          expect(metric_names.sort).to eq(%w{foo foo_2}.sort)
         end
       end
 
@@ -185,13 +185,13 @@ module Librato
 
         it "should create the metrics" do
           metric = Metrics.metrics[0]
-          metric['name'].should == 'foo'
-          metric['type'].should == 'gauge'
+          expect(metric['name']).to eq('foo')
+          expect(metric['type']).to eq('gauge')
         end
 
         it "should store their data" do
           data = Metrics.get_measurements :foo, :count => 1
-          data.should_not be_empty
+          expect(data).not_to be_empty
           data['unassigned'][0]['value'] == 123.0
         end
       end
@@ -204,13 +204,13 @@ module Librato
 
         it "should create the metrics" do
           metric = Metrics.metrics[0]
-          metric['name'].should == 'bar'
-          metric['type'].should == 'counter'
+          expect(metric['name']).to eq('bar')
+          expect(metric['type']).to eq('counter')
         end
 
         it "should store their data" do
           data = Metrics.get_measurements :bar, :count => 1
-          data.should_not be_empty
+          expect(data).not_to be_empty
           data['baz'][0]['value'] == 456.0
         end
       end
@@ -218,12 +218,12 @@ module Librato
       it "should not retain errors" do
         delete_all_metrics
         Metrics.submit :foo => {:type => :counter, :value => 12}
-        lambda {
+        expect {
           Metrics.submit :foo => 15 # submitting as gauge
-        }.should raise_error
-        lambda {
+        }.to raise_error
+        expect {
           Metrics.submit :foo => {:type => :counter, :value => 17}
-        }.should_not raise_error
+        }.not_to raise_error
       end
 
     end
@@ -244,9 +244,9 @@ module Librato
                                           :display_max => 1000
                                         }
             foo = Metrics.get_metric :foo
-            foo['display_name'].should == 'Foo Metric'
-            foo['period'].should == 15
-            foo['attributes']['display_max'].should == 1000
+            expect(foo['display_name']).to eq('Foo Metric')
+            expect(foo['period']).to eq(15)
+            expect(foo['attributes']['display_max']).to eq(1000)
           end
         end
 
@@ -260,20 +260,20 @@ module Librato
                                         :display_max => 1000
                                       }
             foo = Metrics.get_metric :foo
-            foo['display_name'].should == 'Foo Metric'
-            foo['period'].should == 15
-            foo['attributes']['display_max'].should == 1000
+            expect(foo['display_name']).to eq('Foo Metric')
+            expect(foo['period']).to eq(15)
+            expect(foo['attributes']['display_max']).to eq(1000)
           end
 
           it "should raise error if no type specified" do
             delete_all_metrics
-            lambda {
+            expect {
               Metrics.update_metric :foo, :display_name => "Foo Metric",
                                           :period => 15,
                                           :attributes => {
                                             :display_max => 1000
                                           }
-            }.should raise_error
+            }.to raise_error
           end
         end
 
@@ -291,7 +291,7 @@ module Librato
 
           names.each do |name|
              metric = Metrics.get_metric name
-             metric['period'].should == 60
+             expect(metric['period']).to eq(60)
            end
         end
 
@@ -301,11 +301,11 @@ module Librato
 
           %w{my.1 my.2 my.4}.each do |name|
             metric = Metrics.get_metric name
-            metric['attributes']['display_max'].should == 100
+            expect(metric['attributes']['display_max']).to eq(100)
           end
 
           excluded = Metrics.get_metric 'my.3'
-          excluded['attributes']['display_max'].should_not == 100
+          expect(excluded['attributes']['display_max']).not_to eq(100)
         end
       end
     end
@@ -318,21 +318,21 @@ module Librato
       describe "#sources" do
         it "should work" do
           sources = Metrics.sources
-          sources.should be_an(Array)
+          expect(sources).to be_an(Array)
           test_source = sources.detect { |s| s["name"] == "sources_api_test" }
-          test_source["display_name"].should == "Sources Api Test"
+          expect(test_source["display_name"]).to eq("Sources Api Test")
         end
 
         it "should allow filtering by name" do
           sources = Metrics.sources name: 'sources_api_test'
-          sources.all? {|s| s['name'] =~ /sources_api_test/}.should be_true
+          expect(sources.all? {|s| s['name'] =~ /sources_api_test/}).to be_truthy
         end
       end
 
       describe "#get_source" do
         it "should work" do
           test_source = Metrics.get_source("sources_api_test")
-          test_source["display_name"].should == "Sources Api Test"
+          expect(test_source["display_name"]).to eq("Sources Api Test")
         end
       end
 
@@ -341,20 +341,20 @@ module Librato
           Metrics.update_source("sources_api_test", display_name: "Updated Source Name")
 
           test_source = Metrics.get_source("sources_api_test")
-          test_source["display_name"].should == "Updated Source Name"
+          expect(test_source["display_name"]).to eq("Updated Source Name")
         end
 
         it "should create new sources" do
           source_name = "sources_api_test_#{Time.now.to_f}"
-          lambda {
+          expect {
             no_source = Metrics.get_source(source_name)
-          }.should raise_error(Librato::Metrics::NotFound)
+          }.to raise_error(Librato::Metrics::NotFound)
 
           Metrics.update_source(source_name, display_name: "New Source")
 
           test_source = Metrics.get_source(source_name)
-          test_source.should_not be_nil
-          test_source["display_name"].should == "New Source"
+          expect(test_source).not_to be_nil
+          expect(test_source["display_name"]).to eq("New Source")
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,11 @@ require 'librato/metrics'
 
 RSpec.configure do |config|
 
+  # only accept expect syntax instead of should
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+
   # purge all metrics from test account
   def delete_all_metrics
     connection = Librato::Metrics.client.connection
@@ -63,15 +68,6 @@ RSpec.configure do |config|
     end
   end
 
-end
-
-# Ex: 'foobar'.should start_with('foo') #=> true
-#
-RSpec::Matchers.define :start_with do |start_string|
-  match do |string|
-    start_length = start_string.length
-    string[0..start_length-1] == start_string
-  end
 end
 
 # Compares hashes of arrays by converting the arrays to

--- a/spec/unit/metrics/aggregator_spec.rb
+++ b/spec/unit/metrics/aggregator_spec.rb
@@ -11,7 +11,7 @@ module Librato
 
       describe "initialization" do
         context "with specified client" do
-          it "should set to client" do
+          it "sets to client" do
             barney = Client.new
             a = Aggregator.new(:client => barney)
             expect(a.client).to eq(barney)
@@ -19,21 +19,21 @@ module Librato
         end
 
         context "without specified client" do
-          it "should use Librato::Metrics client" do
+          it "uses Librato::Metrics client" do
             a = Aggregator.new
             expect(a.client).to eq(Librato::Metrics.client)
           end
         end
 
         context "with specified source" do
-          it "should set to source" do
+          it "sets to source" do
             a = Aggregator.new(:source => 'rubble')
             expect(a.source).to eq('rubble')
           end
         end
 
         context "without specified source" do
-          it "should not have a source" do
+          it "does not have a source" do
             a = Aggregator.new
             expect(a.source).to be_nil
           end
@@ -41,12 +41,12 @@ module Librato
       end
 
       describe "#add" do
-        it "should allow chaining" do
+        it "allows chaining" do
           expect(subject.add(:foo => 1234)).to eq(subject)
         end
 
         context "with single hash argument" do
-          it "should record a single aggregate" do
+          it "records a single aggregate" do
             subject.add :foo => 3000
             expected = { #:measure_time => @time, TODO: support specific time
                 :gauges => [
@@ -60,7 +60,7 @@ module Librato
             expect(subject.queued).to equal_unordered(expected)
           end
 
-          it "should aggregate multiple measurements" do
+          it "aggregates multiple measurements" do
             subject.add :foo => 1
             subject.add :foo => 2
             subject.add :foo => 3
@@ -77,7 +77,7 @@ module Librato
             expect(subject.queued).to equal_unordered(expected)
           end
 
-          it "should respect source argument" do
+          it "respects source argument" do
             subject.add :foo => {:source => 'alpha', :value => 1}
             subject.add :foo => 5
             subject.add :foo => {:source => :alpha, :value => 6}
@@ -92,7 +92,7 @@ module Librato
           end
 
           context "with a prefix set" do
-            it "should auto-prepend names" do
+            it "auto-prepends names" do
               subject = Aggregator.new(:prefix => 'foo')
               subject.add :bar => 1
               subject.add :bar => 12
@@ -111,7 +111,7 @@ module Librato
         end
 
         context "with multiple hash arguments" do
-          it "should record a single aggregate" do
+          it "records a single aggregate" do
             subject.add :foo => 3000
             subject.add :bar => 30
             expected = {
@@ -132,7 +132,7 @@ module Librato
             expect(subject.queued).to equal_unordered(expected)
           end
 
-          it "should aggregate multiple measurements" do
+          it "aggregates multiple measurements" do
             subject.add :foo => 1
             subject.add :foo => 2
             subject.add :foo => 3
@@ -163,13 +163,13 @@ module Librato
       end
 
       describe "#queued" do
-        it "should include global source if set" do
+        it "includes global source if set" do
           a = Aggregator.new(:source => 'blah')
           a.add :foo => 12
           expect(a.queued[:source]).to eq('blah')
         end
 
-        it "should include global measure_time if set" do
+        it "includes global measure_time if set" do
           measure_time = (Time.now-1000).to_i
           a = Aggregator.new(:measure_time => measure_time)
           a.add :foo => 12
@@ -184,7 +184,7 @@ module Librato
         end
 
         context "when successful" do
-          it "should flush queued metrics and return true" do
+          it "flushes queued metrics and return true" do
             subject.add :steps => 2042, :distance => 1234
             expect(subject.submit).to be true
             expect(subject.empty?).to be true
@@ -192,7 +192,7 @@ module Librato
         end
 
         context "when failed" do
-          it "should preserve queue and return false" do
+          it "preserves queue and return false" do
             subject.add :steps => 2042, :distance => 1234
             subject.persister.return_value(false)
             expect(subject.submit).to be false
@@ -203,7 +203,7 @@ module Librato
 
       describe "#time" do
         context "with metric name only" do
-          it "should queue metric with timed value" do
+          it "queues metric with timed value" do
             1.upto(5) do
               subject.time :sleeping do
                 sleep 0.1
@@ -216,7 +216,7 @@ module Librato
             expect(queued[:sum]).to be_within(150).of(500)
           end
 
-          it "should return the result of the block" do
+          it "returns the result of the block" do
             result = subject.time :returning do
               :hi_there
             end
@@ -233,13 +233,13 @@ module Librato
           client
         end
 
-        it "should not submit immediately" do
+        it "does not submit immediately" do
           timed_agg = Aggregator.new(:client => client, :autosubmit_interval => 1)
           timed_agg.add :foo => 1
           expect(timed_agg.persister.persisted).to be_nil # nothing sent
         end
 
-        it "should submit after interval" do
+        it "submits after interval" do
           timed_agg = Aggregator.new(:client => client, :autosubmit_interval => 1)
           timed_agg.add :foo => 1
           sleep 1

--- a/spec/unit/metrics/aggregator_spec.rb
+++ b/spec/unit/metrics/aggregator_spec.rb
@@ -244,7 +244,7 @@ module Librato
           timed_agg.add :foo => 1
           sleep 1
           timed_agg.add :foo => 2
-          expect(timed_agg.persister.persisted).to_not be_nil # sent
+          expect(timed_agg.persister.persisted).not_to be_nil # sent
         end
       end
 

--- a/spec/unit/metrics/aggregator_spec.rb
+++ b/spec/unit/metrics/aggregator_spec.rb
@@ -6,7 +6,7 @@ module Librato
 
       before(:all) do
         @time = 1354720160 #Time.now.to_i
-        Aggregator.any_instance.stub(:epoch_time).and_return(@time)
+        allow_any_instance_of(Aggregator).to receive(:epoch_time).and_return(@time)
       end
 
       describe "initialization" do

--- a/spec/unit/metrics/aggregator_spec.rb
+++ b/spec/unit/metrics/aggregator_spec.rb
@@ -14,35 +14,35 @@ module Librato
           it "should set to client" do
             barney = Client.new
             a = Aggregator.new(:client => barney)
-            a.client.should be barney
+            expect(a.client).to eq(barney)
           end
         end
 
         context "without specified client" do
           it "should use Librato::Metrics client" do
             a = Aggregator.new
-            a.client.should be Librato::Metrics.client
+            expect(a.client).to eq(Librato::Metrics.client)
           end
         end
 
         context "with specified source" do
           it "should set to source" do
             a = Aggregator.new(:source => 'rubble')
-            a.source.should == 'rubble'
+            expect(a.source).to eq('rubble')
           end
         end
 
         context "without specified source" do
           it "should not have a source" do
             a = Aggregator.new
-            a.source.should be_nil
+            expect(a.source).to be_nil
           end
         end
       end
 
       describe "#add" do
         it "should allow chaining" do
-          subject.add(:foo => 1234).should == subject
+          expect(subject.add(:foo => 1234)).to eq(subject)
         end
 
         context "with single hash argument" do
@@ -57,7 +57,7 @@ module Librato
                   :max => 3000.0}
                 ]
             }
-            subject.queued.should equal_unordered(expected)
+            expect(subject.queued).to equal_unordered(expected)
           end
 
           it "should aggregate multiple measurements" do
@@ -74,7 +74,7 @@ module Librato
                   :max => 5.0}
                 ]
             }
-            subject.queued.should equal_unordered(expected)
+            expect(subject.queued).to equal_unordered(expected)
           end
 
           it "should respect source argument" do
@@ -88,7 +88,7 @@ module Librato
               { :name => 'foo', :count => 2,
                 :sum => 15.0, :min => 5.0, :max => 10.0 }
             ]}
-            subject.queued.should equal_unordered(expected)
+            expect(subject.queued).to equal_unordered(expected)
           end
 
           context "with a prefix set" do
@@ -105,7 +105,7 @@ module Librato
                   }
                 ]
               }
-              subject.queued.should equal_unordered(expected)
+              expect(subject.queued).to equal_unordered(expected)
             end
           end
         end
@@ -129,7 +129,7 @@ module Librato
                   :max => 30.0},
                 ]
             }
-            subject.queued.should equal_unordered(expected)
+            expect(subject.queued).to equal_unordered(expected)
           end
 
           it "should aggregate multiple measurements" do
@@ -157,7 +157,7 @@ module Librato
                   :max => 10.0}
                 ]
             }
-            subject.queued.should equal_unordered(expected)
+            expect(subject.queued).to equal_unordered(expected)
           end
         end
       end
@@ -166,14 +166,14 @@ module Librato
         it "should include global source if set" do
           a = Aggregator.new(:source => 'blah')
           a.add :foo => 12
-          a.queued[:source].should == 'blah'
+          expect(a.queued[:source]).to eq('blah')
         end
 
         it "should include global measure_time if set" do
           measure_time = (Time.now-1000).to_i
           a = Aggregator.new(:measure_time => measure_time)
           a.add :foo => 12
-          a.queued[:measure_time].should == measure_time
+          expect(a.queued[:measure_time]).to eq(measure_time)
         end
       end
 
@@ -186,8 +186,8 @@ module Librato
         context "when successful" do
           it "should flush queued metrics and return true" do
             subject.add :steps => 2042, :distance => 1234
-            subject.submit.should be_true
-            subject.empty?.should be_true
+            expect(subject.submit).to be true
+            expect(subject.empty?).to be true
           end
         end
 
@@ -195,8 +195,8 @@ module Librato
           it "should preserve queue and return false" do
             subject.add :steps => 2042, :distance => 1234
             subject.persister.return_value(false)
-            subject.submit.should be_false
-            subject.empty?.should be_false
+            expect(subject.submit).to be false
+            expect(subject.empty?).to be false
           end
         end
       end
@@ -210,10 +210,10 @@ module Librato
               end
             end
             queued = subject.queued[:gauges][0]
-            queued[:name].should == 'sleeping'
-            queued[:count].should be 5
-            queued[:sum].should be >= 500.0
-            queued[:sum].should be_within(150).of(500)
+            expect(queued[:name]).to eq('sleeping')
+            expect(queued[:count]).to eq(5)
+            expect(queued[:sum]).to be >= 500.0
+            expect(queued[:sum]).to be_within(150).of(500)
           end
 
           it "should return the result of the block" do
@@ -221,7 +221,7 @@ module Librato
               :hi_there
             end
 
-            result.should == :hi_there
+            expect(result).to eq(:hi_there)
           end
         end
       end
@@ -236,7 +236,7 @@ module Librato
         it "should not submit immediately" do
           timed_agg = Aggregator.new(:client => client, :autosubmit_interval => 1)
           timed_agg.add :foo => 1
-          timed_agg.persister.persisted.should be_nil # nothing sent
+          expect(timed_agg.persister.persisted).to be_nil # nothing sent
         end
 
         it "should submit after interval" do
@@ -244,7 +244,7 @@ module Librato
           timed_agg.add :foo => 1
           sleep 1
           timed_agg.add :foo => 2
-          timed_agg.persister.persisted.should_not be_nil # sent
+          expect(timed_agg.persister.persisted).to_not be_nil # sent
         end
       end
 

--- a/spec/unit/metrics/client_spec.rb
+++ b/spec/unit/metrics/client_spec.rb
@@ -29,7 +29,7 @@ module Librato
 
         context "when given two arguments" do
           it "should raise error" do
-            expect{ subject.agent_identifier('test_app', '0.5') }.to raise_error(ArgumentError)
+            expect { subject.agent_identifier('test_app', '0.5') }.to raise_error(ArgumentError)
           end
         end
       end
@@ -64,7 +64,7 @@ module Librato
       describe "#connection" do
         it "should raise exception without authentication" do
           subject.flush_authentication
-          expect{ subject.connection }.to raise_error(Librato::Metrics::CredentialsMissing)
+          expect { subject.connection }.to raise_error(Librato::Metrics::CredentialsMissing)
         end
       end
 
@@ -115,7 +115,7 @@ module Librato
         it "should tolerate muliple metrics" do
           subject.authenticate 'me@librato.com', 'foo'
           subject.persistence = :test
-          expect{ subject.submit :foo => 123, :bar => 456 }.not_to raise_error
+          expect { subject.submit :foo => 123, :bar => 456 }.not_to raise_error
           expected = {:gauges => [{:name => 'foo', :value => 123}, {:name => 'bar', :value => 456}]}
           expect(subject.persister.persisted).to equal_unordered(expected)
         end

--- a/spec/unit/metrics/client_spec.rb
+++ b/spec/unit/metrics/client_spec.rb
@@ -7,20 +7,20 @@ module Librato
 
       describe "#agent_identifier" do
         context "when given a single string argument" do
-          it "should set agent_identifier" do
+          it "sets agent_identifier" do
             subject.agent_identifier 'mycollector/0.1 (dev_id:foo)'
             expect(subject.agent_identifier).to eq('mycollector/0.1 (dev_id:foo)')
           end
         end
 
         context "when given three arguments" do
-          it "should compose an agent string" do
+          it "composes an agent string" do
             subject.agent_identifier('test_app', '0.5', 'foobar')
             expect(subject.agent_identifier).to eq('test_app/0.5 (dev_id:foobar)')
           end
 
           context "when given an empty string" do
-            it "should set to empty" do
+            it "sets to empty" do
               subject.agent_identifier ''
               expect(subject.agent_identifier).to be_empty
             end
@@ -28,20 +28,20 @@ module Librato
         end
 
         context "when given two arguments" do
-          it "should raise error" do
+          it "raises error" do
             expect { subject.agent_identifier('test_app', '0.5') }.to raise_error(ArgumentError)
           end
         end
       end
 
       describe "#api_endpoint" do
-        it "should default to metrics" do
+        it "defaults to metrics" do
           expect(subject.api_endpoint).to eq('https://metrics-api.librato.com')
         end
       end
 
       describe "#api_endpoint=" do
-        it "should set api_endpoint" do
+        it "sets api_endpoint" do
           subject.api_endpoint = 'http://test.com/'
           expect(subject.api_endpoint).to eq('http://test.com/')
         end
@@ -53,7 +53,7 @@ module Librato
 
       describe "#authenticate" do
         context "when given two arguments" do
-          it "should store them as email and api_key" do
+          it "stores them as email and api_key" do
             subject.authenticate 'test@librato.com', 'api_key'
             expect(subject.email).to eq('test@librato.com')
             expect(subject.api_key).to eq('api_key')
@@ -62,14 +62,14 @@ module Librato
       end
 
       describe "#connection" do
-        it "should raise exception without authentication" do
+        it "raises exception without authentication" do
           subject.flush_authentication
           expect { subject.connection }.to raise_error(Librato::Metrics::CredentialsMissing)
         end
       end
 
       describe "#faraday_adapter" do
-        it "should default to Metrics default adapter" do
+        it "defaults to Metrics default adapter" do
           Metrics.faraday_adapter = :typhoeus
           expect(Client.new.faraday_adapter).to eq(Metrics.faraday_adapter)
           Metrics.faraday_adapter = nil
@@ -77,7 +77,7 @@ module Librato
       end
 
       describe "#faraday_adapter=" do
-        it "should allow setting of faraday adapter" do
+        it "allows setting of faraday adapter" do
           subject.faraday_adapter = :excon
           expect(subject.faraday_adapter).to eq(:excon)
           subject.faraday_adapter = :patron
@@ -86,33 +86,33 @@ module Librato
       end
 
       describe "#new_queue" do
-        it "should return a new queue with client set" do
+        it "returns a new queue with client set" do
           queue = subject.new_queue
           expect(queue.client).to eq(subject)
         end
       end
 
       describe "#persistence" do
-        it "should default to direct" do
+        it "defaults to direct" do
           subject.send(:flush_persistence)
           expect(subject.persistence).to eq(:direct)
         end
 
-        it "should allow configuration of persistence method" do
+        it "allows configuration of persistence method" do
           subject.persistence = :fake
           expect(subject.persistence).to eq(:fake)
         end
       end
 
       describe "#submit" do
-        it "should persist metrics immediately" do
+        it "persists metrics immediately" do
           subject.authenticate 'me@librato.com', 'foo'
           subject.persistence = :test
           expect(subject.submit(:foo => 123)).to be true
           expect(subject.persister.persisted).to eq({:gauges => [{:name => 'foo', :value => 123}]})
         end
 
-        it "should tolerate muliple metrics" do
+        it "tolerates muliple metrics" do
           subject.authenticate 'me@librato.com', 'foo'
           subject.persistence = :test
           expect { subject.submit :foo => 123, :bar => 456 }.not_to raise_error

--- a/spec/unit/metrics/client_spec.rb
+++ b/spec/unit/metrics/client_spec.rb
@@ -9,41 +9,41 @@ module Librato
         context "when given a single string argument" do
           it "should set agent_identifier" do
             subject.agent_identifier 'mycollector/0.1 (dev_id:foo)'
-            subject.agent_identifier.should == 'mycollector/0.1 (dev_id:foo)'
+            expect(subject.agent_identifier).to eq('mycollector/0.1 (dev_id:foo)')
           end
         end
 
         context "when given three arguments" do
           it "should compose an agent string" do
             subject.agent_identifier('test_app', '0.5', 'foobar')
-            subject.agent_identifier.should == 'test_app/0.5 (dev_id:foobar)'
+            expect(subject.agent_identifier).to eq('test_app/0.5 (dev_id:foobar)')
           end
 
           context "when given an empty string" do
             it "should set to empty" do
               subject.agent_identifier ''
-              subject.agent_identifier.should == ''
+              expect(subject.agent_identifier).to be_empty
             end
           end
         end
 
         context "when given two arguments" do
           it "should raise error" do
-            lambda { subject.agent_identifier('test_app', '0.5') }.should raise_error(ArgumentError)
+            expect{ subject.agent_identifier('test_app', '0.5') }.to raise_error(ArgumentError)
           end
         end
       end
 
       describe "#api_endpoint" do
         it "should default to metrics" do
-          subject.api_endpoint.should == 'https://metrics-api.librato.com'
+          expect(subject.api_endpoint).to eq('https://metrics-api.librato.com')
         end
       end
 
       describe "#api_endpoint=" do
         it "should set api_endpoint" do
           subject.api_endpoint = 'http://test.com/'
-          subject.api_endpoint.should == 'http://test.com/'
+          expect(subject.api_endpoint).to eq('http://test.com/')
         end
 
         # TODO:
@@ -55,8 +55,8 @@ module Librato
         context "when given two arguments" do
           it "should store them as email and api_key" do
             subject.authenticate 'test@librato.com', 'api_key'
-            subject.email.should == 'test@librato.com'
-            subject.api_key.should == 'api_key'
+            expect(subject.email).to eq('test@librato.com')
+            expect(subject.api_key).to eq('api_key')
           end
         end
       end
@@ -64,43 +64,43 @@ module Librato
       describe "#connection" do
         it "should raise exception without authentication" do
           subject.flush_authentication
-          lambda{ subject.connection }.should raise_error(Librato::Metrics::CredentialsMissing)
+          expect{ subject.connection }.to raise_error(Librato::Metrics::CredentialsMissing)
         end
       end
-      
+
       describe "#faraday_adapter" do
         it "should default to Metrics default adapter" do
           Metrics.faraday_adapter = :typhoeus
-          Client.new.faraday_adapter.should == Metrics.faraday_adapter
+          expect(Client.new.faraday_adapter).to eq(Metrics.faraday_adapter)
           Metrics.faraday_adapter = nil
         end
       end
-   
+
       describe "#faraday_adapter=" do
         it "should allow setting of faraday adapter" do
           subject.faraday_adapter = :excon
-          subject.faraday_adapter.should == :excon
+          expect(subject.faraday_adapter).to eq(:excon)
           subject.faraday_adapter = :patron
-          subject.faraday_adapter.should == :patron
+          expect(subject.faraday_adapter).to eq(:patron)
         end
       end
 
       describe "#new_queue" do
         it "should return a new queue with client set" do
           queue = subject.new_queue
-          queue.client.should be subject
+          expect(queue.client).to eq(subject)
         end
       end
 
       describe "#persistence" do
         it "should default to direct" do
           subject.send(:flush_persistence)
-          subject.persistence.should == :direct
+          expect(subject.persistence).to eq(:direct)
         end
 
         it "should allow configuration of persistence method" do
           subject.persistence = :fake
-          subject.persistence.should == :fake
+          expect(subject.persistence).to eq(:fake)
         end
       end
 
@@ -108,16 +108,16 @@ module Librato
         it "should persist metrics immediately" do
           subject.authenticate 'me@librato.com', 'foo'
           subject.persistence = :test
-          subject.submit(:foo => 123).should eql true
-          subject.persister.persisted.should == {:gauges => [{:name => 'foo', :value => 123}]}
+          expect(subject.submit(:foo => 123)).to be true
+          expect(subject.persister.persisted).to eq({:gauges => [{:name => 'foo', :value => 123}]})
         end
 
         it "should tolerate muliple metrics" do
           subject.authenticate 'me@librato.com', 'foo'
           subject.persistence = :test
-          lambda{ subject.submit :foo => 123, :bar => 456 }.should_not raise_error
+          expect{ subject.submit :foo => 123, :bar => 456 }.to_not raise_error
           expected = {:gauges => [{:name => 'foo', :value => 123}, {:name => 'bar', :value => 456}]}
-          subject.persister.persisted.should equal_unordered(expected)
+          expect(subject.persister.persisted).to equal_unordered(expected)
         end
       end
 

--- a/spec/unit/metrics/client_spec.rb
+++ b/spec/unit/metrics/client_spec.rb
@@ -115,7 +115,7 @@ module Librato
         it "should tolerate muliple metrics" do
           subject.authenticate 'me@librato.com', 'foo'
           subject.persistence = :test
-          expect{ subject.submit :foo => 123, :bar => 456 }.to_not raise_error
+          expect{ subject.submit :foo => 123, :bar => 456 }.not_to raise_error
           expected = {:gauges => [{:name => 'foo', :value => 123}, {:name => 'bar', :value => 456}]}
           expect(subject.persister.persisted).to equal_unordered(expected)
         end

--- a/spec/unit/metrics/connection_spec.rb
+++ b/spec/unit/metrics/connection_spec.rb
@@ -7,13 +7,13 @@ module Librato
 
       describe "#api_endpoint" do
         context "when not provided" do
-          it "should be default" do
+          it "uses default" do
             expect(subject.api_endpoint).to eq('https://metrics-api.librato.com')
           end
         end
 
         context "when provided" do
-          it "should be respected" do
+          it "uses provided endpoint" do
             connection = Connection.new(:api_endpoint => 'http://test.com/')
             expect(connection.api_endpoint).to eq('http://test.com/')
           end
@@ -22,14 +22,14 @@ module Librato
 
       describe "#user_agent" do
         context "without an agent_identifier" do
-          it "should render standard string" do
+          it "renders standard string" do
             connection = Connection.new(:client => Client.new)
             expect(connection.user_agent).to start_with('librato-metrics')
           end
         end
 
         context "with an agent_identifier" do
-          it "should render agent_identifier first" do
+          it "renders agent_identifier first" do
             client = Client.new
             client.agent_identifier('foo', '0.5', 'bar')
             connection = Connection.new(:client => client)
@@ -38,7 +38,7 @@ module Librato
         end
 
         context "with a custom user agent set" do
-          it "should use custom user agent" do
+          it "uses custom user agent" do
             client = Client.new
             client.custom_user_agent = 'foo agent'
             connection = Connection.new(:client => client)
@@ -51,7 +51,7 @@ module Librato
 
       describe "network operations" do
         context "when missing client" do
-          it "should raise exception" do
+          it "raises exception" do
             expect { subject.get 'metrics' }.to raise_error(NoClientProvided)
           end
         end
@@ -64,7 +64,7 @@ module Librato
         end
 
         context "with 400 class errors" do
-          it "should not retry" do
+          it "does not retry" do
             Middleware::CountRequests.reset
             with_rackup('status.ru') do
               expect {
@@ -79,7 +79,7 @@ module Librato
         end
 
         context "with 500 class errors" do
-          it "should retry" do
+          it "retries" do
             Middleware::CountRequests.reset
             with_rackup('status.ru') do
               expect {
@@ -89,7 +89,7 @@ module Librato
             expect(Middleware::CountRequests.total_requests).to eq(4) # did retries
           end
 
-          it "should send consistent body with retries" do
+          it "sends consistent body with retries" do
             Middleware::CountRequests.reset
             status = 0
             begin
@@ -103,7 +103,7 @@ module Librato
               status = error.response[:status].to_i
             end
             expect(Middleware::CountRequests.total_requests).to eq(4) # did retries
-            expect(status).to eq(502) #, 'body should be sent for retries'
+            expect(status).to eq(502) # body is sent for retries
           end
         end
       end

--- a/spec/unit/metrics/connection_spec.rb
+++ b/spec/unit/metrics/connection_spec.rb
@@ -8,14 +8,14 @@ module Librato
       describe "#api_endpoint" do
         context "when not provided" do
           it "should be default" do
-            subject.api_endpoint.should == 'https://metrics-api.librato.com'
+            expect(subject.api_endpoint).to eq('https://metrics-api.librato.com')
           end
         end
 
         context "when provided" do
           it "should be respected" do
             connection = Connection.new(:api_endpoint => 'http://test.com/')
-            connection.api_endpoint.should == 'http://test.com/'
+            expect(connection.api_endpoint).to eq('http://test.com/')
           end
         end
       end
@@ -24,7 +24,7 @@ module Librato
         context "without an agent_identifier" do
           it "should render standard string" do
             connection = Connection.new(:client => Client.new)
-            connection.user_agent.should start_with('librato-metrics')
+            expect(connection.user_agent).to start_with('librato-metrics')
           end
         end
 
@@ -33,7 +33,7 @@ module Librato
             client = Client.new
             client.agent_identifier('foo', '0.5', 'bar')
             connection = Connection.new(:client => client)
-            connection.user_agent.should start_with('foo/0.5')
+            expect(connection.user_agent).to start_with('foo/0.5')
           end
         end
 
@@ -42,7 +42,7 @@ module Librato
             client = Client.new
             client.custom_user_agent = 'foo agent'
             connection = Connection.new(:client => client)
-            connection.user_agent.should == 'foo agent'
+            expect(connection.user_agent).to eq('foo agent')
           end
         end
 
@@ -52,7 +52,7 @@ module Librato
       describe "network operations" do
         context "when missing client" do
           it "should raise exception" do
-            lambda { subject.get 'metrics' }.should raise_error(NoClientProvided)
+            expect{ subject.get 'metrics' }.to raise_error(NoClientProvided)
           end
         end
 
@@ -67,14 +67,14 @@ module Librato
           it "should not retry" do
             Middleware::CountRequests.reset
             with_rackup('status.ru') do
-              lambda {
+              expect{
                 client.connection.transport.post 'not_found'
-              }.should raise_error(NotFound)
-              lambda {
+              }.to raise_error(NotFound)
+              expect{
                 client.connection.transport.post 'forbidden'
-              }.should raise_error(ClientError)
+              }.to raise_error(ClientError)
             end
-            Middleware::CountRequests.total_requests.should == 2 # no retries
+            expect(Middleware::CountRequests.total_requests).to eq(2) # no retries
           end
         end
 
@@ -82,11 +82,11 @@ module Librato
           it "should retry" do
             Middleware::CountRequests.reset
             with_rackup('status.ru') do
-              lambda {
+              expect{
                 client.connection.transport.post 'service_unavailable'
-              }.should raise_error(ServerError)
+              }.to raise_error(ServerError)
             end
-            Middleware::CountRequests.total_requests.should == 4 # did retries
+            expect(Middleware::CountRequests.total_requests).to eq(4) # did retries
           end
 
           it "should send consistent body with retries" do
@@ -102,8 +102,8 @@ module Librato
             rescue Exception => error
               status = error.response[:status].to_i
             end
-            Middleware::CountRequests.total_requests.should == 4 # did retries
-            status.should be(502)#, 'body should be sent for retries'
+            expect(Middleware::CountRequests.total_requests).to eq(4) # did retries
+            expect(status).to eq(502) #, 'body should be sent for retries'
           end
         end
       end

--- a/spec/unit/metrics/connection_spec.rb
+++ b/spec/unit/metrics/connection_spec.rb
@@ -52,7 +52,7 @@ module Librato
       describe "network operations" do
         context "when missing client" do
           it "should raise exception" do
-            expect{ subject.get 'metrics' }.to raise_error(NoClientProvided)
+            expect { subject.get 'metrics' }.to raise_error(NoClientProvided)
           end
         end
 
@@ -67,10 +67,10 @@ module Librato
           it "should not retry" do
             Middleware::CountRequests.reset
             with_rackup('status.ru') do
-              expect{
+              expect {
                 client.connection.transport.post 'not_found'
               }.to raise_error(NotFound)
-              expect{
+              expect {
                 client.connection.transport.post 'forbidden'
               }.to raise_error(ClientError)
             end
@@ -82,7 +82,7 @@ module Librato
           it "should retry" do
             Middleware::CountRequests.reset
             with_rackup('status.ru') do
-              expect{
+              expect {
                 client.connection.transport.post 'service_unavailable'
               }.to raise_error(ServerError)
             end

--- a/spec/unit/metrics/queue/autosubmission_spec.rb
+++ b/spec/unit/metrics/queue/autosubmission_spec.rb
@@ -12,14 +12,14 @@ module Librato
           vol_queue = Queue.new(:client => client, :autosubmit_count => 2)
           vol_queue.add :foo => 1
           vol_queue.add :bar => 2
-          vol_queue.persister.persisted.should_not be_nil # sent
+          expect(vol_queue.persister.persisted).to_not be_nil # sent
         end
 
         it "should not submit if the max has not been reached" do
           vol_queue = Queue.new(:client => client, :autosubmit_count => 5)
           vol_queue.add :foo => 1
           vol_queue.add :bar => 2
-          vol_queue.persister.persisted.should be_nil # nothing sent
+          expect(vol_queue.persister.persisted).to be_nil # nothing sent
         end
 
         it 'should submit when merging' do
@@ -31,8 +31,8 @@ module Librato
 
           queue.merge!(to_merge)
 
-          queue.persister.persisted[:gauges].length.should == 8
-          queue.queued.should be_empty
+          expect(queue.persister.persisted[:gauges].length).to eq(8)
+          expect(queue.queued).to be_empty
         end
       end
 
@@ -40,7 +40,7 @@ module Librato
         it "should not submit immediately" do
           vol_queue = Queue.new(:client => client, :autosubmit_interval => 1)
           vol_queue.add :foo => 1
-          vol_queue.persister.persisted.should be_nil # nothing sent
+          expect(vol_queue.persister.persisted).to be_nil # nothing sent
         end
 
         it "should submit after interval" do
@@ -48,7 +48,7 @@ module Librato
           vol_queue.add :foo => 1
           sleep 1
           vol_queue.add :foo => 2
-          vol_queue.persister.persisted.should_not be_nil # sent
+          expect(vol_queue.persister.persisted).to_not be_nil # sent
         end
       end
 

--- a/spec/unit/metrics/queue/autosubmission_spec.rb
+++ b/spec/unit/metrics/queue/autosubmission_spec.rb
@@ -8,21 +8,21 @@ module Librato
       let(:client) { Client.new.tap{ |c| c.persistence = :test } }
 
       context "with an autosubmit count" do
-        it "should submit when the max is reached" do
+        it "submits when the max is reached" do
           vol_queue = Queue.new(:client => client, :autosubmit_count => 2)
           vol_queue.add :foo => 1
           vol_queue.add :bar => 2
           expect(vol_queue.persister.persisted).not_to be_nil # sent
         end
 
-        it "should not submit if the max has not been reached" do
+        it "does not submit if the max has not been reached" do
           vol_queue = Queue.new(:client => client, :autosubmit_count => 5)
           vol_queue.add :foo => 1
           vol_queue.add :bar => 2
           expect(vol_queue.persister.persisted).to be_nil # nothing sent
         end
 
-        it 'should submit when merging' do
+        it 'submits when merging' do
           queue = Queue.new(:client => client, :autosubmit_count => 5)
           (1..3).each {|i| queue.add "metric_#{i}" => 1 }
 
@@ -37,13 +37,13 @@ module Librato
       end
 
       context "with an autosubmit interval" do
-        it "should not submit immediately" do
+        it "does not submit immediately" do
           vol_queue = Queue.new(:client => client, :autosubmit_interval => 1)
           vol_queue.add :foo => 1
           expect(vol_queue.persister.persisted).to be_nil # nothing sent
         end
 
-        it "should submit after interval" do
+        it "submits after interval" do
           vol_queue = Queue.new(:client => client, :autosubmit_interval => 1)
           vol_queue.add :foo => 1
           sleep 1

--- a/spec/unit/metrics/queue/autosubmission_spec.rb
+++ b/spec/unit/metrics/queue/autosubmission_spec.rb
@@ -12,7 +12,7 @@ module Librato
           vol_queue = Queue.new(:client => client, :autosubmit_count => 2)
           vol_queue.add :foo => 1
           vol_queue.add :bar => 2
-          expect(vol_queue.persister.persisted).to_not be_nil # sent
+          expect(vol_queue.persister.persisted).not_to be_nil # sent
         end
 
         it "should not submit if the max has not been reached" do
@@ -48,7 +48,7 @@ module Librato
           vol_queue.add :foo => 1
           sleep 1
           vol_queue.add :foo => 2
-          expect(vol_queue.persister.persisted).to_not be_nil # sent
+          expect(vol_queue.persister.persisted).not_to be_nil # sent
         end
       end
 

--- a/spec/unit/metrics/queue_spec.rb
+++ b/spec/unit/metrics/queue_spec.rb
@@ -7,7 +7,7 @@ module Librato
 
       before(:each) do
         @time = (Time.now.to_i - 1*60)
-        Queue.any_instance.stub(:epoch_time).and_return(@time)
+        allow_any_instance_of(Queue).to receive(:epoch_time).and_return(@time)
       end
 
       describe "initialization" do

--- a/spec/unit/metrics/queue_spec.rb
+++ b/spec/unit/metrics/queue_spec.rb
@@ -309,7 +309,7 @@ module Librato
 
       describe "#size" do
         it "should return empty if gauges and counters are emtpy" do
-          expect(subject.size).to eq(0)
+          expect(subject.size).to be_zero
         end
         it "should return count of gauges and counters if added" do
           subject.add :transactions => {:type => :counter, :value => 12345},

--- a/spec/unit/metrics/queue_spec.rb
+++ b/spec/unit/metrics/queue_spec.rb
@@ -339,7 +339,7 @@ module Librato
             subject.add :steps => 2042, :distance => 1234
             subject.persister.return_value(false)
             expect(subject.submit).to be false
-            expect(subject.queued).to_not be_empty
+            expect(subject.queued).not_to be_empty
           end
         end
       end

--- a/spec/unit/metrics/queue_spec.rb
+++ b/spec/unit/metrics/queue_spec.rb
@@ -132,7 +132,7 @@ module Librato
           end
 
           it "should raise exception in invalid time" do
-            expect{
+            expect {
               subject.add :foo => {:measure_time => '12', :value => 123}
             }.to raise_error(InvalidMeasureTime)
           end

--- a/spec/unit/metrics/queue_spec.rb
+++ b/spec/unit/metrics/queue_spec.rb
@@ -15,28 +15,28 @@ module Librato
           it "should set to client" do
             barney = Client
             queue = Queue.new(:client => barney)
-            queue.client.should be barney
+            expect(queue.client).to eq(barney)
           end
         end
 
         context "without specified client" do
           it "should use Librato::Metrics client" do
             queue = Queue.new
-            queue.client.should be Librato::Metrics.client
+            expect(queue.client).to eq(Librato::Metrics.client)
           end
         end
       end
 
       describe "#add" do
         it "should allow chaining" do
-          subject.add(:foo => 123).should == subject
+          expect(subject.add(:foo => 123)).to eq(subject)
         end
 
         context "with single hash argument" do
           it "should record a key-value gauge" do
             expected = {:gauges => [{:name => 'foo', :value => 3000, :measure_time => @time}]}
             subject.add :foo => 3000
-            subject.queued.should equal_unordered(expected)
+            expect(subject.queued).to equal_unordered(expected)
           end
         end
 
@@ -44,19 +44,19 @@ module Librato
           it "should record counters" do
             subject.add :total_visits => {:type => :counter, :value => 4000}
             expected = {:counters => [{:name => 'total_visits', :value => 4000, :measure_time => @time}]}
-            subject.queued.should equal_unordered(expected)
+            expect(subject.queued).to equal_unordered(expected)
           end
 
           it "should record gauges" do
             subject.add :temperature => {:type => :gauge, :value => 34}
             expected = {:gauges => [{:name => 'temperature', :value => 34, :measure_time => @time}]}
-            subject.queued.should equal_unordered(expected)
+            expect(subject.queued).to equal_unordered(expected)
           end
 
           it "should accept type key as string or a symbol" do
             subject.add :total_visits => {"type" => "counter", :value => 4000}
             expected = {:counters => [{:name => 'total_visits', :value => 4000, :measure_time => @time}]}
-            subject.queued.should equal_unordered(expected)
+            expect(subject.queued).to equal_unordered(expected)
           end
         end
 
@@ -69,7 +69,7 @@ module Librato
             expected = {:gauges => [{:value => 35.4, :name => 'disk_use', :period => 2,
               :description => 'current disk utilization', :measure_time => measure_time.to_i,
               :source => 'db2'}]}
-            subject.queued.should equal_unordered(expected)
+            expect(subject.queued).to equal_unordered(expected)
           end
 
           context "with a prefix set" do
@@ -79,7 +79,7 @@ module Librato
               subject.add :baz => {:value => 23}
               expected = {:gauges => [{:name =>'foo.bar', :value => 1, :measure_time => @time},
                                       {:name => 'foo.baz', :value => 23, :measure_time => @time}]}
-              subject.queued.should equal_unordered(expected)
+              expect(subject.queued).to equal_unordered(expected)
             end
           end
 
@@ -97,7 +97,7 @@ module Librato
                 {:name => 'foo.bar', :value => 23, :measure_time => @time},
                 {:name => 'foo.bar', :value => 34, :measure_time => @time},
                 {:name => 'bar', :value => 45, :measure_time => @time}]}
-              subject.queued.should equal_unordered(expected)
+              expect(subject.queued).to equal_unordered(expected)
             end
           end
         end
@@ -108,7 +108,7 @@ module Librato
             expected = {:gauges=>[{:name=>"foo", :value=>123, :measure_time => @time},
                                   {:name=>"bar", :value=>345, :measure_time => @time},
                                   {:name=>"baz", :value=>567, :measure_time => @time}]}
-            subject.queued.should equal_unordered(expected)
+            expect(subject.queued).to equal_unordered(expected)
           end
         end
 
@@ -116,25 +116,25 @@ module Librato
           it "should accept time objects" do
             time = Time.now-5
             subject.add :foo => {:measure_time => time, :value => 123}
-            subject.queued[:gauges][0][:measure_time].should == time.to_i
+            expect(subject.queued[:gauges][0][:measure_time]).to eq(time.to_i)
           end
 
           it "should accept integers" do
             time = @time.to_i
             subject.add :foo => {:measure_time => time, :value => 123}
-            subject.queued[:gauges][0][:measure_time].should == time
+            expect(subject.queued[:gauges][0][:measure_time]).to eq(time)
           end
 
           it "should accept strings" do
             time = @time.to_s
             subject.add :foo => {:measure_time => time, :value => 123}
-            subject.queued[:gauges][0][:measure_time].should == time.to_i
+            expect(subject.queued[:gauges][0][:measure_time]).to eq(time.to_i)
           end
 
           it "should raise exception in invalid time" do
-            lambda {
+            expect{
               subject.add :foo => {:measure_time => '12', :value => 123}
-            }.should raise_error(InvalidMeasureTime)
+            }.to raise_error(InvalidMeasureTime)
           end
         end
       end
@@ -143,22 +143,22 @@ module Librato
         it "should return currently queued counters" do
           subject.add :transactions => {:type => :counter, :value => 12345},
                       :register_cents => {:type => :gauge, :value => 211101}
-          subject.counters.should eql [{:name => 'transactions', :value => 12345, :measure_time => @time}]
+          expect(subject.counters).to eq([{:name => 'transactions', :value => 12345, :measure_time => @time}])
         end
 
         it "should return [] when no queued counters" do
-          subject.counters.should eql []
+          expect(subject.counters).to be_empty
         end
       end
 
       describe "#empty?" do
         it "should return true when nothing queued" do
-          subject.empty?.should be_true
+          expect(subject.empty?).to be true
         end
 
         it "should return false with queued items" do
           subject.add :foo => {:type => :gauge, :value => 121212}
-          subject.empty?.should be_false
+          expect(subject.empty?).to be false
         end
       end
 
@@ -166,11 +166,11 @@ module Librato
         it "should return currently queued gauges" do
           subject.add :transactions => {:type => :counter, :value => 12345},
                         :register_cents => {:type => :gauge, :value => 211101}
-          subject.gauges.should eql [{:name => 'register_cents', :value => 211101, :measure_time => @time}]
+          expect(subject.gauges).to eq([{:name => 'register_cents', :value => 211101, :measure_time => @time}])
         end
 
         it "should return [] when no queued gauges" do
-          subject.gauges.should eql []
+          expect(subject.gauges).to be_empty
         end
       end
 
@@ -181,14 +181,14 @@ module Librato
         end
 
         it "should default to nil" do
-          subject.last_submit_time.should be_nil
+          expect(subject.last_submit_time).to be_nil
         end
 
         it "should store last submission time" do
           prior = Time.now
           subject.add :foo => 123
           subject.submit
-          subject.last_submit_time.should >= prior
+          expect(subject.last_submit_time).to be >= prior
         end
       end
 
@@ -203,7 +203,7 @@ module Librato
             expected = {:gauges=>[{:name=>"foo", :value=>123, :measure_time => @time},
                                   {:name=>"bar", :value=>456, :measure_time => @time},
                                   {:name=>"baz", :value=>678, :measure_time => @time}]}
-            q2.queued.should equal_unordered(expected)
+            expect(q2.queued).to equal_unordered(expected)
           end
 
           it "should merge counters" do
@@ -216,7 +216,7 @@ module Librato
             expected = {:counters=>[{:name=>"users", :value=>1000, :measure_time => @time},
                                     {:name=>"sales", :value=>250, :measure_time => @time},
                                     {:name=>"signups", :value=>500, :measure_time => @time}]}
-            q2.queued.should equal_unordered(expected)
+            expect(q2.queued).to equal_unordered(expected)
           end
 
           it "should maintain specified sources" do
@@ -224,7 +224,7 @@ module Librato
             q1.add :neo => {:source => 'matrix', :value => 123}
             q2 = Queue.new(:source => 'red_pill')
             q2.merge!(q1)
-            q2.queued[:gauges][0][:source].should == 'matrix'
+            expect(q2.queued[:gauges][0][:source]).to eq('matrix')
           end
 
           it "should not change default source" do
@@ -232,7 +232,7 @@ module Librato
             q1.add :neo => 456
             q2 = Queue.new(:source => 'red_pill')
             q2.merge!(q1)
-            q2.queued[:source].should == 'red_pill'
+            expect(q2.queued[:source]).to eq('red_pill')
           end
 
           it "should track previous default source" do
@@ -243,7 +243,7 @@ module Librato
             q2.merge!(q1)
             q2.queued[:gauges].each do |gauge|
               if gauge[:name] == 'neo'
-                gauge[:source].should == 'matrix'
+                expect(gauge[:source]).to eq('matrix')
               end
             end
           end
@@ -255,7 +255,7 @@ module Librato
             q2.merge!(q1)
             expected = {:counters => [{:name=>"users", :value=>1000, :measure_time => @time}],
                         :gauges => [{:name=>"foo", :value=>123, :measure_time => @time}]}
-            q2.queued.should == expected
+            expect(q2.queued).to eq(expected)
           end
         end
 
@@ -270,8 +270,7 @@ module Librato
             expected = {:gauges=>[{:name=>"gauge", :value=>42, :measure_time=>@time},
                                   {:name=>"timing", :count=>2, :sum=>305.0, :min=>102.0, :max=>203.0, :source=>"aggregator"}],
                         :source=>'queue'}
-            queue.queued.should equal_unordered(expected)
-
+            expect(queue.queued).to equal_unordered(expected)
           end
         end
 
@@ -281,15 +280,15 @@ module Librato
                         :counters=>[{:name => 'bar', :value => 456}]}
             q = Queue.new
             q.merge!(to_merge)
-            q.gauges.length.should == 1
-            q.counters.length.should == 1
+            expect(q.gauges.length).to eq(1)
+            expect(q.counters.length).to eq(1)
           end
         end
       end
 
       describe "#per_request" do
         it "should default to 500" do
-          subject.per_request.should == 500
+          expect(subject.per_request).to eq(500)
         end
       end
 
@@ -297,27 +296,27 @@ module Librato
         it "should include global source if set" do
           q = Queue.new(:source => 'blah')
           q.add :foo => 12
-          q.queued[:source].should == 'blah'
+          expect(q.queued[:source]).to eq('blah')
         end
 
         it "should include global measure_time if set" do
           measure_time = (Time.now-1000).to_i
           q = Queue.new(:measure_time => measure_time)
           q.add :foo => 12
-          q.queued[:measure_time].should == measure_time
+          expect(q.queued[:measure_time]).to eq(measure_time)
         end
       end
 
       describe "#size" do
         it "should return empty if gauges and counters are emtpy" do
-          subject.size.should eq 0
+          expect(subject.size).to eq(0)
         end
         it "should return count of gauges and counters if added" do
           subject.add :transactions => {:type => :counter, :value => 12345},
               :register_cents => {:type => :gauge, :value => 211101}
           subject.add :transactions => {:type => :counter, :value => 12345},
                       :register_cents => {:type => :gauge, :value => 211101}
-          subject.size.should eql 4
+          expect(subject.size).to eq(4)
         end
       end
 
@@ -330,8 +329,8 @@ module Librato
         context "when successful" do
           it "should flush queued metrics and return true" do
             subject.add :steps => 2042, :distance => 1234
-            subject.submit.should be_true
-            subject.queued.should be_empty
+            expect(subject.submit).to be true
+            expect(subject.queued).to be_empty
           end
         end
 
@@ -339,8 +338,8 @@ module Librato
           it "should preserve queue and return false" do
             subject.add :steps => 2042, :distance => 1234
             subject.persister.return_value(false)
-            subject.submit.should be_false
-            subject.queued.should_not be_empty
+            expect(subject.submit).to be false
+            expect(subject.queued).to_not be_empty
           end
         end
       end
@@ -352,9 +351,9 @@ module Librato
               sleep 0.1
             end
             queued = subject.queued[:gauges][0]
-            queued[:name].should == 'sleeping'
-            queued[:value].should be >= 100
-            queued[:value].should be_within(30).of(100)
+            expect(queued[:name]).to eq('sleeping')
+            expect(queued[:value]).to be >= 100
+            expect(queued[:value]).to be_within(30).of(100)
           end
         end
 
@@ -364,11 +363,11 @@ module Librato
               sleep 0.05
             end
             queued = subject.queued[:gauges][0]
-            queued[:name].should == 'sleep_two'
-            queued[:period].should == 2
-            queued[:source].should == 'app1'
-            queued[:value].should be >= 50
-            queued[:value].should be_within(30).of(50)
+            expect(queued[:name]).to eq('sleep_two')
+            expect(queued[:period]).to eq(2)
+            expect(queued[:source]).to eq('app1')
+            expect(queued[:value]).to be >= 50
+            expect(queued[:value]).to be_within(30).of(50)
           end
         end
       end

--- a/spec/unit/metrics/queue_spec.rb
+++ b/spec/unit/metrics/queue_spec.rb
@@ -12,7 +12,7 @@ module Librato
 
       describe "initialization" do
         context "with specified client" do
-          it "should set to client" do
+          it "sets to client" do
             barney = Client
             queue = Queue.new(:client => barney)
             expect(queue.client).to eq(barney)
@@ -20,7 +20,7 @@ module Librato
         end
 
         context "without specified client" do
-          it "should use Librato::Metrics client" do
+          it "uses Librato::Metrics client" do
             queue = Queue.new
             expect(queue.client).to eq(Librato::Metrics.client)
           end
@@ -28,12 +28,12 @@ module Librato
       end
 
       describe "#add" do
-        it "should allow chaining" do
+        it "allows chaining" do
           expect(subject.add(:foo => 123)).to eq(subject)
         end
 
         context "with single hash argument" do
-          it "should record a key-value gauge" do
+          it "records a key-value gauge" do
             expected = {:gauges => [{:name => 'foo', :value => 3000, :measure_time => @time}]}
             subject.add :foo => 3000
             expect(subject.queued).to equal_unordered(expected)
@@ -41,19 +41,19 @@ module Librato
         end
 
         context "with specified metric type" do
-          it "should record counters" do
+          it "records counters" do
             subject.add :total_visits => {:type => :counter, :value => 4000}
             expected = {:counters => [{:name => 'total_visits', :value => 4000, :measure_time => @time}]}
             expect(subject.queued).to equal_unordered(expected)
           end
 
-          it "should record gauges" do
+          it "records gauges" do
             subject.add :temperature => {:type => :gauge, :value => 34}
             expected = {:gauges => [{:name => 'temperature', :value => 34, :measure_time => @time}]}
             expect(subject.queued).to equal_unordered(expected)
           end
 
-          it "should accept type key as string or a symbol" do
+          it "accepts type key as string or a symbol" do
             subject.add :total_visits => {"type" => "counter", :value => 4000}
             expected = {:counters => [{:name => 'total_visits', :value => 4000, :measure_time => @time}]}
             expect(subject.queued).to equal_unordered(expected)
@@ -61,7 +61,7 @@ module Librato
         end
 
         context "with extra attributes" do
-          it "should record" do
+          it "records" do
             measure_time = Time.now
             subject.add :disk_use => {:value => 35.4, :period => 2,
               :description => 'current disk utilization', :measure_time => measure_time,
@@ -73,7 +73,7 @@ module Librato
           end
 
           context "with a prefix set" do
-            it "should auto-prepend names" do
+            it "auto-prepends names" do
               subject = Queue.new(:prefix => 'foo')
               subject.add :bar => 1
               subject.add :baz => {:value => 23}
@@ -84,7 +84,7 @@ module Librato
           end
 
           context "when dynamically changing prefix" do
-            it "should auto-append names" do
+            it "auto-appends names" do
               subject.add :bar => 12
               subject.prefix = 'foo' # with string
               subject.add :bar => 23
@@ -103,7 +103,7 @@ module Librato
         end
 
         context "with multiple metrics" do
-          it "should record" do
+          it "records" do
             subject.add :foo => 123, :bar => 345, :baz => 567
             expected = {:gauges=>[{:name=>"foo", :value=>123, :measure_time => @time},
                                   {:name=>"bar", :value=>345, :measure_time => @time},
@@ -113,25 +113,25 @@ module Librato
         end
 
         context "with a measure_time" do
-          it "should accept time objects" do
+          it "accepts time objects" do
             time = Time.now-5
             subject.add :foo => {:measure_time => time, :value => 123}
             expect(subject.queued[:gauges][0][:measure_time]).to eq(time.to_i)
           end
 
-          it "should accept integers" do
+          it "accepts integers" do
             time = @time.to_i
             subject.add :foo => {:measure_time => time, :value => 123}
             expect(subject.queued[:gauges][0][:measure_time]).to eq(time)
           end
 
-          it "should accept strings" do
+          it "accepts strings" do
             time = @time.to_s
             subject.add :foo => {:measure_time => time, :value => 123}
             expect(subject.queued[:gauges][0][:measure_time]).to eq(time.to_i)
           end
 
-          it "should raise exception in invalid time" do
+          it "raises exception in invalid time" do
             expect {
               subject.add :foo => {:measure_time => '12', :value => 123}
             }.to raise_error(InvalidMeasureTime)
@@ -140,36 +140,36 @@ module Librato
       end
 
       describe "#counters" do
-        it "should return currently queued counters" do
+        it "returns currently queued counters" do
           subject.add :transactions => {:type => :counter, :value => 12345},
                       :register_cents => {:type => :gauge, :value => 211101}
           expect(subject.counters).to eq([{:name => 'transactions', :value => 12345, :measure_time => @time}])
         end
 
-        it "should return [] when no queued counters" do
+        it "returns [] when no queued counters" do
           expect(subject.counters).to be_empty
         end
       end
 
       describe "#empty?" do
-        it "should return true when nothing queued" do
+        it "returns true when nothing queued" do
           expect(subject.empty?).to be true
         end
 
-        it "should return false with queued items" do
+        it "returns false with queued items" do
           subject.add :foo => {:type => :gauge, :value => 121212}
           expect(subject.empty?).to be false
         end
       end
 
       describe "#gauges" do
-        it "should return currently queued gauges" do
+        it "returns currently queued gauges" do
           subject.add :transactions => {:type => :counter, :value => 12345},
                         :register_cents => {:type => :gauge, :value => 211101}
           expect(subject.gauges).to eq([{:name => 'register_cents', :value => 211101, :measure_time => @time}])
         end
 
-        it "should return [] when no queued gauges" do
+        it "returns [] when no queued gauges" do
           expect(subject.gauges).to be_empty
         end
       end
@@ -180,11 +180,11 @@ module Librato
           Librato::Metrics.persistence = :test
         end
 
-        it "should default to nil" do
+        it "defaults to nil" do
           expect(subject.last_submit_time).to be_nil
         end
 
-        it "should store last submission time" do
+        it "stores last submission time" do
           prior = Time.now
           subject.add :foo => 123
           subject.submit
@@ -194,7 +194,7 @@ module Librato
 
       describe "#merge!" do
         context "with another queue" do
-          it "should merge gauges" do
+          it "merges gauges" do
             q1 = Queue.new
             q1.add :foo => 123, :bar => 456
             q2 = Queue.new
@@ -206,7 +206,7 @@ module Librato
             expect(q2.queued).to equal_unordered(expected)
           end
 
-          it "should merge counters" do
+          it "merges counters" do
             q1 = Queue.new
             q1.add :users => {:type => :counter, :value => 1000}
             q1.add :sales => {:type => :counter, :value => 250}
@@ -219,7 +219,7 @@ module Librato
             expect(q2.queued).to equal_unordered(expected)
           end
 
-          it "should maintain specified sources" do
+          it "maintains specified sources" do
             q1 = Queue.new
             q1.add :neo => {:source => 'matrix', :value => 123}
             q2 = Queue.new(:source => 'red_pill')
@@ -227,7 +227,7 @@ module Librato
             expect(q2.queued[:gauges][0][:source]).to eq('matrix')
           end
 
-          it "should not change default source" do
+          it "does not change default source" do
             q1 = Queue.new(:source => 'matrix')
             q1.add :neo => 456
             q2 = Queue.new(:source => 'red_pill')
@@ -235,7 +235,7 @@ module Librato
             expect(q2.queued[:source]).to eq('red_pill')
           end
 
-          it "should track previous default source" do
+          it "tracks previous default source" do
             q1 = Queue.new(:source => 'matrix')
             q1.add :neo => 456
             q2 = Queue.new(:source => 'red_pill')
@@ -248,7 +248,7 @@ module Librato
             end
           end
 
-          it "should handle empty cases" do
+          it "handles empty cases" do
             q1 = Queue.new
             q1.add :foo => 123, :users => {:type => :counter, :value => 1000}
             q2 = Queue.new
@@ -260,7 +260,7 @@ module Librato
         end
 
         context "with an aggregator" do
-          it "should merge" do
+          it "merges" do
             aggregator = Aggregator.new(:source => 'aggregator')
             aggregator.add :timing => 102
             aggregator.add :timing => 203
@@ -275,7 +275,7 @@ module Librato
         end
 
         context "with a hash" do
-          it "should merge" do
+          it "merges" do
             to_merge = {:gauges=>[{:name => 'foo', :value => 123}],
                         :counters=>[{:name => 'bar', :value => 456}]}
             q = Queue.new
@@ -287,19 +287,19 @@ module Librato
       end
 
       describe "#per_request" do
-        it "should default to 500" do
+        it "defaults to 500" do
           expect(subject.per_request).to eq(500)
         end
       end
 
       describe "#queued" do
-        it "should include global source if set" do
+        it "includes global source if set" do
           q = Queue.new(:source => 'blah')
           q.add :foo => 12
           expect(q.queued[:source]).to eq('blah')
         end
 
-        it "should include global measure_time if set" do
+        it "includes global measure_time if set" do
           measure_time = (Time.now-1000).to_i
           q = Queue.new(:measure_time => measure_time)
           q.add :foo => 12
@@ -308,10 +308,10 @@ module Librato
       end
 
       describe "#size" do
-        it "should return empty if gauges and counters are emtpy" do
+        it "returns empty if gauges and counters are emtpy" do
           expect(subject.size).to be_zero
         end
-        it "should return count of gauges and counters if added" do
+        it "returns count of gauges and counters if added" do
           subject.add :transactions => {:type => :counter, :value => 12345},
               :register_cents => {:type => :gauge, :value => 211101}
           subject.add :transactions => {:type => :counter, :value => 12345},
@@ -327,7 +327,7 @@ module Librato
         end
 
         context "when successful" do
-          it "should flush queued metrics and return true" do
+          it "flushes queued metrics and return true" do
             subject.add :steps => 2042, :distance => 1234
             expect(subject.submit).to be true
             expect(subject.queued).to be_empty
@@ -335,7 +335,7 @@ module Librato
         end
 
         context "when failed" do
-          it "should preserve queue and return false" do
+          it "preserves queue and return false" do
             subject.add :steps => 2042, :distance => 1234
             subject.persister.return_value(false)
             expect(subject.submit).to be false
@@ -346,7 +346,7 @@ module Librato
 
       describe "#time" do
         context "with metric name only" do
-          it "should queue metric with timed value" do
+          it "queues metric with timed value" do
             subject.time :sleeping do
               sleep 0.1
             end
@@ -358,7 +358,7 @@ module Librato
         end
 
         context "with metric and options" do
-          it "should queue metric with value and options" do
+          it "queues metric with value and options" do
             subject.time :sleep_two, :source => 'app1', :period => 2 do
               sleep 0.05
             end

--- a/spec/unit/metrics_spec.rb
+++ b/spec/unit/metrics_spec.rb
@@ -16,7 +16,7 @@ module Librato
 
    describe "#faraday_adapter" do
      it "should return current default adapter" do
-       expect(Metrics.faraday_adapter).to_not be_nil
+       expect(Metrics.faraday_adapter).not_to be_nil
      end
    end
 
@@ -53,7 +53,7 @@ module Librato
      end
 
      it "should tolerate multiple metrics" do
-       expect{ Librato::Metrics.submit :foo => 123, :bar => 456 }.to_not raise_error
+       expect{ Librato::Metrics.submit :foo => 123, :bar => 456 }.not_to raise_error
        expected = {:gauges => [{:name => 'foo', :value => 123}, {:name => 'bar', :value => 456}]}
        expect(Librato::Metrics.persister.persisted).to equal_unordered(expected)
      end

--- a/spec/unit/metrics_spec.rb
+++ b/spec/unit/metrics_spec.rb
@@ -6,7 +6,7 @@ module Librato
 
    describe "#authorize" do
      context "when given two arguments" do
-       it "should store them on simple" do
+       it "stores them on simple" do
          Metrics.authenticate 'tester@librato.com', 'api_key'
          expect(Metrics.client.email).to eq('tester@librato.com')
          expect(Metrics.client.api_key).to eq('api_key')
@@ -15,7 +15,7 @@ module Librato
    end
 
    describe "#faraday_adapter" do
-     it "should return current default adapter" do
+     it "returns current default adapter" do
        expect(Metrics.faraday_adapter).not_to be_nil
      end
    end
@@ -24,7 +24,7 @@ module Librato
      before(:all) { @current_adapter = Metrics.faraday_adapter }
      after(:all) { Metrics.faraday_adapter = @current_adapter }
 
-     it "should allow setting of faraday adapter" do
+     it "allows setting of faraday adapter" do
        Metrics.faraday_adapter = :excon
        expect(Metrics.faraday_adapter).to eq(:excon)
        Metrics.faraday_adapter = :patron
@@ -33,7 +33,7 @@ module Librato
    end
 
    describe "#persistence" do
-     it "should allow configuration of persistence method" do
+     it "allows configuration of persistence method" do
        Metrics.persistence = :test
        expect(Metrics.persistence).to eq(:test)
      end
@@ -46,13 +46,13 @@ module Librato
      end
      after(:all) { Librato::Metrics.client.flush_authentication }
 
-     it "should persist metrics immediately" do
+     it "persists metrics immediately" do
        Metrics.persistence = :test
        expect(Metrics.submit(:foo => 123)).to be true
        expect(Metrics.persister.persisted).to eq({:gauges => [{:name => 'foo', :value => 123}]})
      end
 
-     it "should tolerate multiple metrics" do
+     it "tolerates multiple metrics" do
        expect { Librato::Metrics.submit :foo => 123, :bar => 456 }.not_to raise_error
        expected = {:gauges => [{:name => 'foo', :value => 123}, {:name => 'bar', :value => 456}]}
        expect(Librato::Metrics.persister.persisted).to equal_unordered(expected)

--- a/spec/unit/metrics_spec.rb
+++ b/spec/unit/metrics_spec.rb
@@ -8,34 +8,34 @@ module Librato
      context "when given two arguments" do
        it "should store them on simple" do
          Metrics.authenticate 'tester@librato.com', 'api_key'
-         Metrics.client.email.should == 'tester@librato.com'
-         Metrics.client.api_key.should == 'api_key'
+         expect(Metrics.client.email).to eq('tester@librato.com')
+         expect(Metrics.client.api_key).to eq('api_key')
        end
      end
    end
-   
+
    describe "#faraday_adapter" do
      it "should return current default adapter" do
-       Metrics.faraday_adapter.should_not be nil
+       expect(Metrics.faraday_adapter).to_not be_nil
      end
    end
-   
+
    describe "#faraday_adapter=" do
      before(:all) { @current_adapter = Metrics.faraday_adapter }
      after(:all) { Metrics.faraday_adapter = @current_adapter }
-     
+
      it "should allow setting of faraday adapter" do
        Metrics.faraday_adapter = :excon
-       Metrics.faraday_adapter.should == :excon
+       expect(Metrics.faraday_adapter).to eq(:excon)
        Metrics.faraday_adapter = :patron
-       Metrics.faraday_adapter.should == :patron
+       expect(Metrics.faraday_adapter).to eq(:patron)
      end
    end
 
    describe "#persistence" do
      it "should allow configuration of persistence method" do
        Metrics.persistence = :test
-       Metrics.persistence.should == :test
+       expect(Metrics.persistence).to eq(:test)
      end
    end
 
@@ -48,14 +48,14 @@ module Librato
 
      it "should persist metrics immediately" do
        Metrics.persistence = :test
-       Metrics.submit(:foo => 123).should eql true
-       Metrics.persister.persisted.should == {:gauges => [{:name => 'foo', :value => 123}]}
+       expect(Metrics.submit(:foo => 123)).to be true
+       expect(Metrics.persister.persisted).to eq({:gauges => [{:name => 'foo', :value => 123}]})
      end
 
      it "should tolerate multiple metrics" do
-       lambda{ Librato::Metrics.submit :foo => 123, :bar => 456 }.should_not raise_error
+       expect{ Librato::Metrics.submit :foo => 123, :bar => 456 }.to_not raise_error
        expected = {:gauges => [{:name => 'foo', :value => 123}, {:name => 'bar', :value => 456}]}
-       Librato::Metrics.persister.persisted.should equal_unordered(expected)
+       expect(Librato::Metrics.persister.persisted).to equal_unordered(expected)
      end
    end
 

--- a/spec/unit/metrics_spec.rb
+++ b/spec/unit/metrics_spec.rb
@@ -53,7 +53,7 @@ module Librato
      end
 
      it "should tolerate multiple metrics" do
-       expect{ Librato::Metrics.submit :foo => 123, :bar => 456 }.not_to raise_error
+       expect { Librato::Metrics.submit :foo => 123, :bar => 456 }.not_to raise_error
        expected = {:gauges => [{:name => 'foo', :value => 123}, {:name => 'bar', :value => 456}]}
        expect(Librato::Metrics.persister.persisted).to equal_unordered(expected)
      end


### PR DESCRIPTION
Upgrade rspec from 2.6 to 3.5. Update existing unit and integration tests to only use `expect` syntax and modern conventions.

2.0 roadmap: #110 

cc @nextmat @bdehamer 