### PR TITLE
Fix SmartJSON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.1.7
   - 2.2.3
   - 2.3.0
+  - 2.3.1
   - jruby-19mode
   # - rbx
   - ruby-head

--- a/lib/librato/metrics/smart_json.rb
+++ b/lib/librato/metrics/smart_json.rb
@@ -4,37 +4,21 @@ module Librato
       extend SingleForwardable
 
       if defined?(::MultiJson)
-        if RUBY_VERSION <= "2.3.0"
+        def self.read(json)
           # MultiJSON >= 1.3.0
           if MultiJson.respond_to?(:load)
-            def_delegator MultiJson, :load, :read
+            MultiJson.load(json)
           else
-            def_delegator MultiJson, :decode, :read
+            MultiJson.decode(json)
           end
+        end
 
+        def self.write(json)
           # MultiJSON <= 1.2.0
           if MultiJson.respond_to?(:dump)
-            def_delegator MultiJson, :dump, :write
+            MultiJson.dump(json)
           else
-            def_delegator MultiJson, :encode, :write
-          end
-        else
-          def self.read(json)
-            # MultiJSON >= 1.3.0
-            if MultiJson.respond_to?(:load)
-              MultiJson.load(json)
-            else
-              MultiJson.decode(json)
-            end
-          end
-
-          def self.write(json)
-            # MultiJSON <= 1.2.0
-            if MultiJson.respond_to?(:dump)
-              MultiJson.dump(json)
-            else
-              MultiJson.encode(json)
-            end
+            MultiJson.encode(json)
           end
         end
 
@@ -44,17 +28,12 @@ module Librato
       else
         require "json"
 
-        if RUBY_VERSION <= "2.3.0"
-          def_delegator JSON, :parse, :read
-          def_delegator JSON, :generate, :write
-        else
-          def self.read(json)
-            JSON.parse(json)
-          end
+        def self.read(json)
+          JSON.parse(json)
+        end
 
-          def self.write(json)
-            JSON.generate(json)
-          end
+        def self.write(json)
+          JSON.generate(json)
         end
 
         def self.handler

--- a/lib/librato/metrics/smart_json.rb
+++ b/lib/librato/metrics/smart_json.rb
@@ -1,8 +1,6 @@
 module Librato
   module Metrics
     class SmartJSON
-      extend SingleForwardable
-
       if defined?(::MultiJson)
         def self.read(json)
           # MultiJSON >= 1.3.0

--- a/lib/librato/metrics/smart_json.rb
+++ b/lib/librato/metrics/smart_json.rb
@@ -4,18 +4,38 @@ module Librato
       extend SingleForwardable
 
       if defined?(::MultiJson)
-        # MultiJSON >= 1.3.0
-        if MultiJson.respond_to?(:load)
-          def_delegator MultiJson, :load, :read
-        else
-          def_delegator MultiJson, :decode, :read
-        end
+        if RUBY_VERSION <= "2.3.0"
+          # MultiJSON >= 1.3.0
+          if MultiJson.respond_to?(:load)
+            def_delegator MultiJson, :load, :read
+          else
+            def_delegator MultiJson, :decode, :read
+          end
 
-        # MultiJSON <= 1.2.0
-        if MultiJson.respond_to?(:dump)
-          def_delegator MultiJson, :dump, :write
+          # MultiJSON <= 1.2.0
+          if MultiJson.respond_to?(:dump)
+            def_delegator MultiJson, :dump, :write
+          else
+            def_delegator MultiJson, :encode, :write
+          end
         else
-          def_delegator MultiJson, :encode, :write
+          def self.read(json)
+            # MultiJSON >= 1.3.0
+            if MultiJson.respond_to?(:load)
+              MultiJson.load(json)
+            else
+              MultiJson.decode(json)
+            end
+          end
+
+          def self.write(json)
+            # MultiJSON <= 1.2.0
+            if MultiJson.respond_to?(:dump)
+              MultiJson.dump(json)
+            else
+              MultiJson.encode(json)
+            end
+          end
         end
 
         def self.handler
@@ -24,8 +44,18 @@ module Librato
       else
         require "json"
 
-        def_delegator JSON, :parse, :read
-        def_delegator JSON, :generate, :write
+        if RUBY_VERSION <= "2.3.0"
+          def_delegator JSON, :parse, :read
+          def_delegator JSON, :generate, :write
+        else
+          def self.read(json)
+            JSON.parse(json)
+          end
+
+          def self.write(json)
+            JSON.generate(json)
+          end
+        end
 
         def self.handler
           :json


### PR DESCRIPTION
Fix for https://github.com/librato/librato-metrics/issues/122. Add `2.3.1` to CI build matrix. Wrap methods instead of delegation. `def_delegator` raises a `NoMethodError` when adding delegation for objects:

```ruby
RUBY_VERSION
# => "2.3.0"
require 'forwardable'
require 'json'

obj = Object.new
obj.extend SingleForwardable
obj.def_delegator JSON, :parse
obj.parse("{\"abc\":\"def\"}")
# => {"abc"=>"def"}
```

```ruby
RUBY_VERSION
# => "2.3.1"
require 'forwardable'
require 'json'

obj = Object.new
obj.extend SingleForwardable
obj.def_delegator JSON, :parse
NoMethodError: undefined method `method_defined?' for #<Object:0x007f86888e7c48>
```

https://bugs.ruby-lang.org/issues/12393