### PR TITLE
Pass only part of env to raised errors in middleware

### DIFF
--- a/lib/librato/metrics/middleware/expects_status.rb
+++ b/lib/librato/metrics/middleware/expects_status.rb
@@ -8,17 +8,17 @@ module Librato
           # TODO: make exception output prettier
           case env[:status]
           when 401
-            raise Unauthorized, response_values(env)
+            raise Unauthorized, "unauthorized", response_values(env)
           when 403
-            raise Forbidden, response_values(env)
+            raise Forbidden, "forbidden", response_values(env)
           when 404
-            raise NotFound, response_values(env)
+            raise NotFound, "not_found", response_values(env)
           when 422
-            raise EntityAlreadyExists, response_values(env)
+            raise EntityAlreadyExists, "entity_already_exists", response_values(env)
           when 400..499
-            raise ClientError, response_values(env)
+            raise ClientError, "client_error", response_values(env)
           when 500..599
-            raise ServerError, response_values(env)
+            raise ServerError, "server_error", response_values(env)
           end
         end
 

--- a/lib/librato/metrics/middleware/expects_status.rb
+++ b/lib/librato/metrics/middleware/expects_status.rb
@@ -8,22 +8,28 @@ module Librato
           # TODO: make exception output prettier
           case env[:status]
           when 401
-            raise Unauthorized.new(env.to_s, env)
+            raise Unauthorized, response_values(env)
           when 403
-            raise Forbidden.new(env.to_s, env)
+            raise Forbidden, response_values(env)
           when 404
-            raise NotFound.new(env.to_s, env)
+            raise NotFound, response_values(env)
           when 422
-            raise EntityAlreadyExists.new(env.to_s, env)
+            raise EntityAlreadyExists, response_values(env)
           when 400..499
-            raise ClientError.new(env.to_s, env)
+            raise ClientError, response_values(env)
           when 500..599
-            raise ServerError.new(env.to_s, env)
+            raise ServerError, response_values(env)
           end
         end
 
+        def response_values(env)
+          {
+            status: env.status,
+            headers: env.response_headers,
+            body: env.body
+          }
+        end
       end
-
     end
   end
 end

--- a/lib/librato/metrics/middleware/expects_status.rb
+++ b/lib/librato/metrics/middleware/expects_status.rb
@@ -15,10 +15,8 @@ module Librato
             raise NotFound, response_values(env)
           when 422
             raise EntityAlreadyExists, response_values(env)
-          when 400..499
+          when 400..599
             raise ClientError, response_values(env)
-          when 500..599
-            raise ServerError, response_values(env)
           end
         end
 

--- a/lib/librato/metrics/middleware/expects_status.rb
+++ b/lib/librato/metrics/middleware/expects_status.rb
@@ -15,8 +15,10 @@ module Librato
             raise NotFound, response_values(env)
           when 422
             raise EntityAlreadyExists, response_values(env)
-          when 400..599
+          when 400..499
             raise ClientError, response_values(env)
+          when 500..599
+            raise ServerError, response_values(env)
           end
         end
 

--- a/lib/librato/metrics/middleware/expects_status.rb
+++ b/lib/librato/metrics/middleware/expects_status.rb
@@ -8,17 +8,17 @@ module Librato
           # TODO: make exception output prettier
           case env[:status]
           when 401
-            raise Unauthorized, "unauthorized", response_values(env)
+            raise Unauthorized.new("unauthorized", response_values(env))
           when 403
-            raise Forbidden, "forbidden", response_values(env)
+            raise Forbidden.new("forbidden", response_values(env))
           when 404
-            raise NotFound, "not_found", response_values(env)
+            raise NotFound.new("not_found", response_values(env))
           when 422
-            raise EntityAlreadyExists, "entity_already_exists", response_values(env)
+            raise EntityAlreadyExists.new("entity_already_exists", response_values(env))
           when 400..499
-            raise ClientError, "client_error", response_values(env)
+            raise ClientError.new("client_error", response_values(env))
           when 500..599
-            raise ServerError, "server_error", response_values(env)
+            raise ServerError.new("server_error", response_values(env))
           end
         end
 


### PR DESCRIPTION
Passing everything means that if it raise to an error tracker you might
end up leaking credentials.

Raising the whole `env` will also leak request headers like
Authorization.

The fact that the first parameter is a string means a lot of the bug
trackers won't filter and scrub it.

```
Librato::Metrics::ClientError: #<struct Faraday::Env method=:post,
body="{\"errors\":{\"params\":{\"measurements\":[\"No measurements
found\"]}},\"request_time\":1476218695}", url=#<URI::HTTPS
https://metrics-api.librato.com/v1/metrics>,
request=#<Faraday::RequestOptions timeout=30, open_timeout=20>,
request_headers={"User-Agent"=>"librato-metrics/1.6.1 (ruby; 2.3.1p112;
x86_64-linux) direct-faraday/0.9.2", "Content-Type"=>"application/json",
"Authorization"=>"Basic
NOT_REDACTED_IN_BUG_TRACKER=="},
ssl=#<Faraday::SSLOptions verify=true>, parallel_manager=nil,
params=nil, response=#<Faraday::Response:0x007f1454966fa8
@on_complete_callbacks=[], @env=#<Faraday::Env @method=:post
@body="{\"errors\":{\"params\":{\"measurements\":[\"No measurements
found\"]}},\"request_time\":1476218695}" @url=#<URI::HTTPS
https://metrics-api.librato.com/v1/metrics>
@request=#<Faraday::RequestOptions timeout=30, open_timeout=20>
@request_headers={"User-Agent"=>"librato-metrics/1.6.1 (ruby; 2.3.1p112;
x86_64-linux) direct-faraday/0.9.2", "Content-Type"=>"application/json",
"Authorization"=>"Basic
NOT_REDACTED_IN_BUG_TRACKER=="}
@ssl=#<Faraday::SSLOptions verify=true>
@response=#<Faraday::Response:0x007f1454966fa8 ...>
@response_headers={"content-type"=>"application/json", "date"=>"Tue, 11
Oct 2016 20:44:55 GMT", "server"=>"nginx", "content-length"=>"90",
"connection"=>"Close"} @status=400 @custom={:request_body=>"{}"}>>,
response_headers={"content-type"=>"application/json", "date"=>"Tue, 11
Oct 2016 20:44:55 GMT", "server"=>"nginx", "content-length"=>"90",
"connection"=>"Close"}, status=400>
```

Work here is simply taking https://github.com/lostisland/faraday/blob/master/lib/faraday/response/raise_error.rb
and applying it here.
