### PR TITLE
Sanitize request information passed to exceptions

### DIFF
--- a/lib/librato/metrics/middleware/expects_status.rb
+++ b/lib/librato/metrics/middleware/expects_status.rb
@@ -8,22 +8,28 @@ module Librato
           # TODO: make exception output prettier
           case env[:status]
           when 401
-            raise Unauthorized.new(env.to_s, env)
+            raise Unauthorized.new("unauthorized", response_values(env))
           when 403
-            raise Forbidden.new(env.to_s, env)
+            raise Forbidden.new("forbidden", response_values(env))
           when 404
-            raise NotFound.new(env.to_s, env)
+            raise NotFound.new("not_found", response_values(env))
           when 422
-            raise EntityAlreadyExists.new(env.to_s, env)
+            raise EntityAlreadyExists.new("entity_already_exists", response_values(env))
           when 400..499
-            raise ClientError.new(env.to_s, env)
+            raise ClientError.new("client_error", response_values(env))
           when 500..599
-            raise ServerError.new(env.to_s, env)
+            raise ServerError.new("server_error", response_values(env))
           end
         end
 
+        def response_values(env)
+          {
+            status: env.status,
+            headers: env.response_headers,
+            body: env.body
+          }
+        end
       end
-
     end
   end
 end

--- a/lib/librato/metrics/middleware/expects_status.rb
+++ b/lib/librato/metrics/middleware/expects_status.rb
@@ -5,28 +5,30 @@ module Librato
       class ExpectsStatus < Faraday::Response::Middleware
 
         def on_complete(env)
-          # TODO: make exception output prettier
           case env[:status]
           when 401
-            raise Unauthorized.new("unauthorized", response_values(env))
+            raise Unauthorized, sanitize_request(env)
           when 403
-            raise Forbidden.new("forbidden", response_values(env))
+            raise Forbidden, sanitize_request(env)
           when 404
-            raise NotFound.new("not_found", response_values(env))
+            raise NotFound, sanitize_request(env)
           when 422
-            raise EntityAlreadyExists.new("entity_already_exists", response_values(env))
+            raise EntityAlreadyExists, sanitize_request(env)
           when 400..499
-            raise ClientError.new("client_error", response_values(env))
+            raise ClientError, sanitize_request(env)
           when 500..599
-            raise ServerError.new("server_error", response_values(env))
+            raise ServerError, sanitize_request(env)
           end
         end
 
-        def response_values(env)
+        def sanitize_request(env)
           {
             status: env.status,
-            headers: env.response_headers,
-            body: env.body
+            url: env.url.to_s,
+            user_agent: env.request_headers["User-Agent"],
+            request_body: env[:request_body],
+            response_headers: env.response_headers,
+            response_body: env.body
           }
         end
       end

--- a/lib/librato/metrics/middleware/expects_status.rb
+++ b/lib/librato/metrics/middleware/expects_status.rb
@@ -5,19 +5,20 @@ module Librato
       class ExpectsStatus < Faraday::Response::Middleware
 
         def on_complete(env)
+          sanitized = sanitize_request(env)
           case env[:status]
           when 401
-            raise Unauthorized, sanitize_request(env)
+            raise Unauthorized.new(sanitized.to_s, sanitized)
           when 403
-            raise Forbidden, sanitize_request(env)
+            raise Forbidden.new(sanitized.to_s, sanitized)
           when 404
-            raise NotFound, sanitize_request(env)
+            raise NotFound.new(sanitized.to_s, sanitized)
           when 422
-            raise EntityAlreadyExists, sanitize_request(env)
+            raise EntityAlreadyExists.new(sanitized.to_s, sanitized)
           when 400..499
-            raise ClientError, sanitize_request(env)
+            raise ClientError.new(sanitized.to_s, sanitized)
           when 500..599
-            raise ServerError, sanitize_request(env)
+            raise ServerError.new(sanitized.to_s, sanitized)
           end
         end
 


### PR DESCRIPTION
Extended version of #126 to include debugging information we commonly need when helping customers.

Put the important debugging info back in the exception message as well since otherwise customers won't see it in most cases. Since it has been sanitized this should be okay.

@ys - appreciate any thoughts you have on this, will probably merge tomorrow.