### PR TITLE
Don't submit the queue when empty

### DIFF
--- a/lib/librato/metrics/processor.rb
+++ b/lib/librato/metrics/processor.rb
@@ -40,7 +40,7 @@ module Librato
       #
       # @return Boolean
       def submit
-        return true if self.queued.empty?
+        return true if self.empty?
         options = {per_request: @per_request}
         if persister.persist(self.client, self.queued, options)
           @last_submit_time = Time.now

--- a/lib/librato/metrics/queue.rb
+++ b/lib/librato/metrics/queue.rb
@@ -75,7 +75,7 @@ module Librato
       #
       # @return Boolean
       def empty?
-        @queued.empty?
+        gauges.empty? && counters.empty? && measurements.empty?
       end
 
       # Remove all queued metrics

--- a/spec/unit/metrics/queue_spec.rb
+++ b/spec/unit/metrics/queue_spec.rb
@@ -301,6 +301,11 @@ module Librato
           subject.add foo: {type: :gauge, value: 121212}
           expect(subject.empty?).to be false
         end
+
+        it "returns true when nothing merged" do
+          subject.merge!(Librato::Metrics::Aggregator.new)
+          expect(subject.empty?).to be true
+        end
       end
 
       describe "#gauges" do
@@ -312,6 +317,14 @@ module Librato
 
         it "returns [] when no queued gauges" do
           expect(subject.gauges).to be_empty
+        end
+
+        context "when there are no metrics" do
+          it "it does not persist and returns true" do
+            subject.merge!(Librato::Metrics::Aggregator.new)
+            subject.persister.return_value(false)
+            expect(subject.submit).to be true
+          end
         end
       end
 


### PR DESCRIPTION
Currently it's checking queued.empty? which always turns out
to be non-empty if you provide a source.

This check relies on just `empty?` which only utilizes `@queued`
without the merging of the global metadata.