### PR TITLE
Access Faraday environment using `#[]`

### DIFF
--- a/lib/librato/metrics/middleware/expects_status.rb
+++ b/lib/librato/metrics/middleware/expects_status.rb
@@ -24,12 +24,12 @@ module Librato
 
         def sanitize_request(env)
           {
-            status: env.status,
-            url: env.url.to_s,
-            user_agent: env.request_headers["User-Agent"],
+            status: env[:status],
+            url: env[:url].to_s,
+            user_agent: (env[:request_headers] || {})["User-Agent"],
             request_body: env[:request_body],
-            response_headers: env.response_headers,
-            response_body: env.body
+            response_headers: env[:response_headers],
+            response_body: env[:body]
           }
         end
       end


### PR DESCRIPTION
We're seeing `env` come through as a `Hash` rather than a
`Faraday::Response` here. Faraday's middleware docs are poor, but it
seems common to look up environment values using `[]` rather than
relying on the methods of `Response`, presumably because this can
happen.

If it makes a difference, we're using Faraday 0.8.11, but `librato-metrics` does not specify any version requirements.