### PR TITLE
initial setup for working with charts and spaces

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gemspec
 
 gem 'rake'
 
+gem 'typhoeus'
+
 # docs
 gem 'yard'
 

--- a/lib/librato/chart.rb
+++ b/lib/librato/chart.rb
@@ -1,0 +1,37 @@
+class Librato::Chart < OpenStruct
+  include Librato::Utils
+  attr_reader :creation_response
+
+  REQUIRED_KEYS = [
+    :space_id,
+    :type,
+    :name,
+    :streams
+  ]
+
+  def save
+    self.class.new safe_parse(creation_response.response_body) if valid?
+  end
+
+  private
+
+  def valid?
+    REQUIRED_KEYS.none?{ |k| send(k).nil? }
+  end
+
+  def chart_url
+    "#{SPACES_URL}/#{space_id}/charts"
+  end
+
+  def creation_response
+    @creation_response ||= client(chart_url, body: creation_payload, method: :post).run
+  end
+
+  def creation_payload
+    {
+      type:    type,
+      name:    name,
+      streams: streams
+    }
+  end
+end

--- a/lib/librato/metrics.rb
+++ b/lib/librato/metrics.rb
@@ -3,6 +3,7 @@ $:.unshift(File.dirname(__FILE__)) unless
 
 require 'base64'
 require 'forwardable'
+require 'typhoeus'
 
 require 'metrics/aggregator'
 require 'metrics/annotator'
@@ -15,6 +16,10 @@ require 'metrics/queue'
 require 'metrics/smart_json'
 require 'metrics/util'
 require 'metrics/version'
+
+require 'utils'
+require 'chart'
+require 'space'
 
 module Librato
 

--- a/lib/librato/space.rb
+++ b/lib/librato/space.rb
@@ -1,0 +1,27 @@
+class Librato::Space < OpenStruct
+  class << self
+    include Librato::Utils
+
+    def find(id)
+      new safe_parse(show_response(id))
+    end
+
+    def find_by_name(name)
+      all.detect { |space| space.name == name }
+    end
+
+    def all
+      safe_parse(index_response).fetch('spaces').map { |space| new space }
+    end
+
+    private
+
+    def index_response
+      client(SPACES_URL).run.response_body
+    end
+
+    def show_response(id)
+      client("#{SPACES_URL}/#{id}").run.response_body
+    end
+  end
+end

--- a/lib/librato/utils.rb
+++ b/lib/librato/utils.rb
@@ -1,0 +1,18 @@
+module Librato::Utils
+  LIBRATO_USER    = ENV['LIBRATO_USER']
+  LIBRATO_API_KEY = ENV['LIBRATO_TOKEN']
+  SPACES_URL = 'https://metrics-api.librato.com/v1/spaces'.freeze
+
+  def safe_parse(json_string)
+    JSON.parse json_string
+  rescue JSON::ParserError
+    {}
+  end
+
+  def client(url, options = {})
+    Typhoeus::Request.new(url, userpwd: "#{LIBRATO_USER}:#{LIBRATO_API_KEY}",
+                                method:  options.fetch(:method, :get),
+                                body:    options.fetch(:body, {})
+                          )
+  end
+end

--- a/spec/unit/chart_spec.rb
+++ b/spec/unit/chart_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+module Librato
+  describe Chart do
+    let(:params) do
+      {
+        space_id: 0,
+        type: 'line',
+        name: 'test',
+        streams:[{ "metric": "librato.chart.creation.spec" }]
+      }
+    end
+    let(:chart){ described_class.new(params) }
+    let(:new_chart){ chart.save }
+    let(:new_chart_id) { 1 }
+    let(:mock_response) do
+      double(
+        response_body: { chart_id: new_chart_id }.to_json
+      )
+    end
+
+    describe '#initialize' do
+      it 'sets required attributes' do
+        expect(chart).to have_attributes(
+          {
+            name: params[:name],
+            type: params[:type],
+            streams: params[:streams],
+            space_id: params[:space_id]
+          }
+        )
+      end
+
+      it 'raises an error for missing keys' do
+        expect{ described_class.new }.to raise_error(ArgumentError)
+      end
+    end
+
+    describe '#save' do
+      before do
+        allow_any_instance_of(Typhoeus::Request).to receive(:run).and_return(mock_response)
+      end
+
+      it 'saves the chart' do
+        expect(new_chart.chart_id).to eql(new_chart_id)
+      end
+    end
+  end
+end

--- a/spec/unit/space_spec.rb
+++ b/spec/unit/space_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+module Librato
+  describe Space do
+    let(:all_spaces_response) do
+      double(
+        response_body: {
+          spaces: [
+            {
+              id: 1,
+              name: 'space 1'
+            },
+            {
+              id: 2,
+              name: 'space 2'
+            }
+          ]}.to_json
+      )
+    end
+
+    let(:single_space_response) do
+      double(
+        response_body: {
+            id: 1,
+            name: 'space 1'
+          }.to_json
+      )
+    end
+
+    describe '.find' do
+      before do
+        allow_any_instance_of(Typhoeus::Request).to receive(:run).and_return(single_space_response)
+      end
+      it 'returns a space by id' do
+        expect(Librato::Space.find(1)).to_not be_nil
+      end
+    end
+
+    describe '.find_by_name' do
+      before do
+        allow_any_instance_of(Typhoeus::Request).to receive(:run).and_return(all_spaces_response)
+      end
+      it 'returns a space by name' do
+        expect(Librato::Space.find_by_name('space 1')).to_not be_nil
+      end
+    end
+
+    describe '.all' do
+      before do
+        allow_any_instance_of(Typhoeus::Request).to receive(:run).and_return(all_spaces_response)
+      end
+      it 'returns all spaces' do
+        expect(Librato::Space.all).to be_an Array
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds functionality for fetching space id by name, and saving a new chart.

```ruby
Space.all
Space.find(id)
Space.find_by_name('Test Space')

Chart.new(
  space_id: 0,
  type: 'line',
  name: 'test',
  streams:[{ "metric": "librato.chart.creation.spec" }]
).save

```