### PR TITLE
Relax faraday version range constraint to allow newer Rubies

### DIFF
--- a/lib/librato/metrics/middleware/retry.rb
+++ b/lib/librato/metrics/middleware/retry.rb
@@ -16,7 +16,7 @@ module Librato
             env[:body] = request_body # after failure is set to response body
             @app.call(env)
           rescue Librato::Metrics::ServerError, Timeout::Error,
-                 Faraday::Error::ConnectionFailed
+                 Faraday::ConnectionFailed
             if retries > 0
               retries -= 1 and retry
             end

--- a/librato-metrics.gemspec
+++ b/librato-metrics.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w[LICENSE]
 
   ## runtime dependencies
-  s.add_dependency 'faraday', '~> 0.7'
+  s.add_dependency 'faraday', ['>= 0.7', '< 2.0']
   s.add_dependency 'multi_json'
   s.add_dependency 'aggregate', '~> 0.2.2'
 


### PR DESCRIPTION
Closes https://github.com/librato/librato-metrics/issues/142.

---

This pull request relaxes the faraday version constraint so that consumers of this gem can use [newer versions of faraday that support Ruby 2.7](https://github.com/lostisland/faraday/blob/v0.17.1/CHANGELOG.md#v0171).

Please note that this pull request targets the librato-metrics 1.x branch, as [some Librato customers cannot upgrade to 2.x](https://www.librato.com/docs/kb/faq/account_questions/tags_or_sources/).

Because [faraday 1.0 introduces a breaking change regarding the namespacing of its error classes](https://github.com/lostisland/faraday/blob/v1.0.0/UPGRADING.md#faraday-10), this pull request updates the `Faraday::Error::ConnectionFailed` reference to use `Faraday::ConnectionFailed` instead. This change is backwards compatible with older versions of faraday. Without that change, you see the following failure when running the test suite with faraday 1.0.0:

```
$ bundle exec rake
bin/ruby -S bundle exec rspec --color spec/unit/metrics/aggregator_spec.rb spec/unit/metrics/client_spec.rb spec/unit/metrics/connection_spec.rb spec/unit/metrics/queue/autosubmission_spec.rb spec/unit/metrics/queue_spec.rb spec/unit/metrics_spec.rb
........................................F.....................................................

Failures:

  1) Librato::Metrics::Connection network operations with 400 class errors should not retry
     Failure/Error: lambda {
       expected Librato::Metrics::NotFound, got #<NameError: uninitialized constant Faraday::Error::ConnectionFailed
       Did you mean?  Faraday::ConnectionFailed>
     # ./spec/unit/metrics/connection_spec.rb:70:in `block (5 levels) in <module:Metrics>'
     # ./spec/unit/metrics/connection_spec.rb:69:in `block (4 levels) in <module:Metrics>'

Finished in 4.03 seconds
94 examples, 1 failure

Failed examples:

rspec ./spec/unit/metrics/connection_spec.rb:67 # Librato::Metrics::Connection network operations with 400 class errors should not retry
rake aborted!
ruby -S bundle exec rspec --color spec/unit/metrics/aggregator_spec.rb spec/unit/metrics/client_spec.rb spec/unit/metrics/connection_spec.rb spec/unit/metrics/queue/autosubmission_spec.rb spec/unit/metrics/queue_spec.rb spec/unit/metrics_spec.rb failed
/private/tmp/librato-metrics/Rakefile:28:in `block in <top (required)>'
bin/bundle:23:in `load'
bin/bundle:23:in `<main>'
Command failed with status (1): [bin/ruby -S...]
/private/tmp/librato-metrics/Rakefile:28:in `block in <top (required)>'
bin/bundle:23:in `load'
bin/bundle:23:in `<main>'
Tasks: TOP => default => spec
(See full trace by running task with --trace)
```