### PR TITLE
fix: Avoid deprecation warning about #basic_auth on Faraday::Connection

### DIFF
--- a/lib/librato/metrics/connection.rb
+++ b/lib/librato/metrics/connection.rb
@@ -44,7 +44,7 @@ module Librato
         end.tap do |transport|
           transport.headers[:user_agent] = user_agent
           transport.headers[:content_type] = 'application/json'
-          transport.basic_auth @client.email, @client.api_key
+          transport.request :basic_auth, @client.email, @client.api_key
         end
       end
 

--- a/lib/librato/metrics/connection.rb
+++ b/lib/librato/metrics/connection.rb
@@ -44,7 +44,12 @@ module Librato
         end.tap do |transport|
           transport.headers[:user_agent] = user_agent
           transport.headers[:content_type] = 'application/json'
-          transport.request :basic_auth, @client.email, @client.api_key
+          # The Basic Auth middleware usage differs before and after Faraday v2
+          if Gem::Version.new(Faraday::VERSION).segments.first >= 2
+            transport.request :authorization, :basic, @client.email, @client.api_key
+          else
+            transport.request :basic_auth, @client.email, @client.api_key
+          end          
         end
       end
 


### PR DESCRIPTION
This change avoids a deprecation warning.

The authentication method "helpers" have been moved out of the Connection object.

This change makes us use the "request middleware called ":basic_auth" directly, instead.

## Details

- https://lostisland.github.io/faraday/middleware/authentication
- https://github.com/lostisland/faraday/blob/main/UPGRADING.md#authentication-helper-methods-in-connection-have-been-removed
- Include both the upcoming Faraday 2.0 signature, too.

## Notes

While doing this, I noted that the test suite does not run, so I added a new GitHub Actions CI configuration, in #148.