### PR TITLE
[1.x] Avoid deprecation warning about #basic_auth on Faraday::Connection

### DIFF
--- a/lib/librato/metrics/connection.rb
+++ b/lib/librato/metrics/connection.rb
@@ -44,7 +44,7 @@ module Librato
         end.tap do |transport|
           transport.headers[:user_agent] = user_agent
           transport.headers[:content_type] = 'application/json'
-          transport.basic_auth @client.email, @client.api_key
+          transport.request :basic_auth, @client.email, @client.api_key
         end
       end
 


### PR DESCRIPTION
This PR fixes a deprecation warning about Faraday.

## Background

The `#basic_auth` helper method will be removed in 2.0, and this changes the code to use the middleware itself instead.

This implements the same thing as https://github.com/librato/librato-metrics/pull/147, but for `librato-metrics` 1.x.