### PR TITLE
Allow open_timeout and read_timeout to be set from ENV vars

### DIFF
--- a/lib/librato/metrics/connection.rb
+++ b/lib/librato/metrics/connection.rb
@@ -32,7 +32,7 @@ module Librato
         raise(NoClientProvided, "No client provided.") unless @client
         @transport ||= Faraday::Connection.new(
           url: api_endpoint + "/v1/",
-          request: {open_timeout: 20, timeout: 30}) do |f|
+          request: { open_timeout: open_timeout, timeout: read_timeout }) do |f|
 
           f.use Librato::Metrics::Middleware::RequestBody
           f.use Librato::Metrics::Middleware::Retry
@@ -79,6 +79,14 @@ module Librato
         else
           adapter
         end
+      end
+
+      def open_timeout
+        ENV.fetch("LIBRATO_OPEN_TIMEOUT", 20)
+      end
+
+      def read_timeout
+        ENV.fetch("LIBRATO_READ_TIMEOUT", 30)
       end
 
       def ruby_engine


### PR DESCRIPTION
`open_timeout` and `read_timeout` are hardcoded to 20 and 30 respectively. It would be nice if these values could be configured.